### PR TITLE
Fix severe bugs when confirming and dropping participants

### DIFF
--- a/src/commands/tournament.ts
+++ b/src/commands/tournament.ts
@@ -77,7 +77,7 @@ export async function getPlayerDeck(msg: Message, args: string[]): Promise<void>
 	const deck = DiscordDeck.constructFromRecord(record);
 	const discordUser = bot.users.get(user);
 	await deck.sendProfile(
-		msg.channel.id,
+		msg.channel,
 		discordUser ? `${discordUser.username}#${discordUser.discriminator}ydk` : user
 	);
 }

--- a/src/discordDeck.ts
+++ b/src/discordDeck.ts
@@ -1,9 +1,8 @@
 import { Deck } from "./deck";
-import { Message, MessageContent, MessageFile, TextChannel } from "eris";
+import { Message, MessageContent, MessageFile, TextChannel, PrivateChannel } from "eris";
 import fetch from "node-fetch";
 import { extractURLs } from "ydke";
-import { bot } from "./bot";
-import { DeckNotFoundError, AssertTextChannelError } from "./errors";
+import { DeckNotFoundError } from "./errors";
 
 export class DiscordDeck extends Deck {
 	private static async messageToYdk(msg: Message): Promise<string> {
@@ -46,11 +45,7 @@ export class DiscordDeck extends Deck {
 		return outStrings;
 	}
 
-	public async sendProfile(channelId: string, filename: string): Promise<Message> {
-		const channel = bot.getChannel(channelId);
-		if (!(channel instanceof TextChannel)) {
-			throw new AssertTextChannelError(channelId);
-		}
+	public async sendProfile(channel: PrivateChannel | TextChannel, filename: string): Promise<Message> {
 		const profile = await this.getProfile();
 		const title = "Contents of your deck:\n";
 		const mainCount =
@@ -154,10 +149,10 @@ export class DiscordDeck extends Deck {
 		return await channel.createMessage(out, file);
 	}
 
-	public static async sendProfile(msg: Message, channel?: string, filename?: string): Promise<Message> {
+	public static async sendProfile(msg: Message, channel?: PrivateChannel | TextChannel, filename?: string): Promise<Message> {
 		const deck = await DiscordDeck.constructFromMessage(msg);
 		if (!channel) {
-			channel = msg.channel.id;
+			channel = msg.channel;
 		}
 		if (!filename) {
 			filename = `${msg.author.username}#${msg.author.discriminator}.ydk`;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -2,8 +2,12 @@ import { connect, connection } from "mongoose";
 import { mongoDbUrl } from "../config/env";
 import logger from "../logger";
 
-connect(mongoDbUrl, { useCreateIndex: true, useNewUrlParser: true, useUnifiedTopology: true })
-	.then(() => logger.info(`Connected to MongoDB at ${process.env.MONGODB_URL}`))
+connect(mongoDbUrl, {
+	useCreateIndex: true,
+	useNewUrlParser: true,
+	useUnifiedTopology: true,
+	useFindAndModify: false
+}).then(() => logger.info(`Connected to MongoDB at ${process.env.MONGODB_URL}`))
 	.catch(logger.error);
 
 process.on("SIGINT", () => {


### PR DESCRIPTION
- Avoid potential race condition in actions:removePendingParticipant and actions:removeConfirmedParticipant
- Fix bad logic in messageReactionRemove that was asserting for the existence of users already removed
- discordDeck:sendProfile accepts PrivateChannel | TextChannel instead of string as argument since all use cases already have the Eris channel