### PR TITLE
Add handling for progressing rounds with all scores submitted

### DIFF
--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -92,6 +92,11 @@ export class WebsiteInterface {
 		await this.api.submitScore(tournamentId, winner, winnerScore, loserScore);
 	}
 
+	public async getOpenMatchCount(tournamentId: string): Promise<number> {
+		const matches = await this.api.getMatches(tournamentId);
+		return matches.length;
+	}
+
 	public async tieMatches(tournamentId: string): Promise<void> {
 		const matches = await this.api.getMatches(tournamentId);
 		// we can use either player to report a tie, the submitScore logic will make it a tie


### PR DESCRIPTION
Challonge automatically proceeds to the next round when it has all the scores, which leaves a round full of matches open to be tied up by the next round command. Now we check if that many matches are open, and if so do not issue ties.