### PR TITLE
Compose: separate Postgres and Mongo configurations

### DIFF
--- a/docker-compose.mongo.yaml
+++ b/docker-compose.mongo.yaml
@@ -1,0 +1,25 @@
+version: "3.8"
+services:
+  mongo:
+    image: mongo:latest
+    ports:
+      - "27017:27017"
+    volumes:
+      - tournamentdb:/data/db
+    restart: unless-stopped
+  bot:
+    build: .
+    environment:
+      DISCORD_TOKEN: ${DISCORD_TOKEN}
+      OCTOKIT_TOKEN: ${OCTOKIT_TOKEN}
+      MONGODB_URL: mongodb://mongo:27017/tournamentdb
+      CHALLONGE_USERNAME: ${CHALLONGE_USERNAME}
+      CHALLONGE_TOKEN: ${CHALLONGE_TOKEN}
+      POSTGRESQL_URL: UNUSED
+    volumes:
+      - ./dbs:/app/dbs
+      - ./logs:/app/logs
+    restart: unless-stopped
+
+volumes:
+  tournamentdb:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,5 @@
 version: "3.8"
 services:
-  mongo:
-    image: mongo:latest
-    ports:
-      - "27017:27017"
-    volumes:
-      - tournamentdb:/data/db
-    restart: unless-stopped
   postgres:
     image: postgres:alpine
     user: postgres
@@ -26,15 +19,16 @@ services:
     environment:
       DISCORD_TOKEN: ${DISCORD_TOKEN}
       OCTOKIT_TOKEN: ${OCTOKIT_TOKEN}
-      MONGODB_URL: mongodb://mongo:27017/tournamentdb
+      MONGODB_URL: UNUSED
       CHALLONGE_USERNAME: ${CHALLONGE_USERNAME}
       CHALLONGE_TOKEN: ${CHALLONGE_TOKEN}
       POSTGRESQL_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/${POSTGRES_DB}"
+      EMCEE_USE_POSTGRES: 1
     volumes:
       - ./dbs:/app/dbs
       - ./logs:/app/logs
+      - ./ormlogs.log:/app/ormlogs.log
     restart: unless-stopped
 
 volumes:
-  tournamentdb:
   database:

--- a/src/database/orm/index.ts
+++ b/src/database/orm/index.ts
@@ -13,7 +13,8 @@ export async function initializeConnection(postgresqlUrl: string): Promise<void>
 		url: postgresqlUrl,
 		entities: [ChallongeTournament, ConfirmedParticipant, Countdown, Participant, RegisterMessage],
 		logging: true,
-		synchronize: process.env.NODE_ENV === "development"
+		logger: "file", // TODO: not ideal, synchronous, file location cannot be changed, but custom logger is broken
+		synchronize: true // TODO: process.env.NODE_ENV === "development" and investigate migrations
 	});
 	logger.info(`Connected to PostgreSQL via TypeORM`);
 }


### PR DESCRIPTION
Warning: touch ormlogs.log first before starting or it will mount incorrectly. This is a temporary workaround