### PR TITLE
Remove nextRound's functionality to tie outstanding matches

### DIFF
--- a/src/CommandHandler.ts
+++ b/src/CommandHandler.ts
@@ -210,12 +210,8 @@ export class CommandHandler {
 	private async commandNextRound(msg: DiscordMessageIn, args: string[]): Promise<void> {
 		const [id] = this.validateArgs(args, 1);
 		await this.tournamentManager.authenticateHost(id, msg.author);
-		const round = await this.tournamentManager.nextRound(id);
-		if (round === -1) {
-			await msg.reply(`Tournament ${id} successfully progressed past final round and completed.`);
-			return;
-		}
-		await msg.reply(`Tournament ${id} successfully progressed to round ${round}.`);
+		await this.tournamentManager.nextRound(id);
+		await msg.reply(`New round successfully started for Tournament ${id}.`);
 	}
 
 	private async commandListPlayers(msg: DiscordMessageIn, args: string[]): Promise<void> {

--- a/src/CommandHandler.ts
+++ b/src/CommandHandler.ts
@@ -24,6 +24,7 @@ export class CommandHandler {
 		this.discord.registerCommand("removehost", this.commandRemoveHost.bind(this));
 		this.discord.registerCommand("open", this.commandOpenTournament.bind(this));
 		this.discord.registerCommand("start", this.commandStartTournament.bind(this));
+		this.discord.registerCommand("finish", this.commandFinishTournament.bind(this));
 		this.discord.registerCommand("cancel", this.commandCancelTournament.bind(this));
 		this.discord.registerCommand("score", this.commandSubmitScore.bind(this));
 		this.discord.registerCommand("forcescore", this.commandSubmitScoreHost.bind(this));
@@ -161,10 +162,17 @@ export class CommandHandler {
 		await msg.reply(`Tournament ${id} successfully commenced!`);
 	}
 
+	private async commandFinishTournament(msg: DiscordMessageIn, args: string[]): Promise<void> {
+		const [id] = this.validateArgs(args, 1);
+		await this.tournamentManager.authenticateHost(id, msg.author);
+		await this.tournamentManager.finishTournament(id, false);
+		await msg.reply(`Tournament ${id} successfully canceled.`);
+	}
+
 	private async commandCancelTournament(msg: DiscordMessageIn, args: string[]): Promise<void> {
 		const [id] = this.validateArgs(args, 1);
 		await this.tournamentManager.authenticateHost(id, msg.author);
-		await this.tournamentManager.cancelTournament(id);
+		await this.tournamentManager.finishTournament(id, true);
 		await msg.reply(`Tournament ${id} successfully canceled.`);
 	}
 

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -31,7 +31,6 @@ export interface TournamentInterface {
 	removeHost(tournamentId: string, newHost: string): Promise<void>;
 	openTournament(tournamentId: string): Promise<void>;
 	startTournament(tournamentId: string): Promise<void>;
-	cancelTournament(tournamentId: string): Promise<void>;
 	finishTournament(tournamentId: string, cancel: boolean | undefined): Promise<void>;
 	submitScore(
 		tournamentId: string,
@@ -468,10 +467,6 @@ export class TournamentManager implements TournamentInterface {
 		}
 	}
 
-	public async cancelTournament(tournamentId: string): Promise<void> {
-		await this.finishTournament(tournamentId, true);
-	}
-
 	public async submitScore(
 		tournamentId: string,
 		playerId: string,
@@ -545,11 +540,6 @@ export class TournamentManager implements TournamentInterface {
 	// hosts should handle outstanding scores individually with forcescore
 	public async nextRound(tournamentId: string): Promise<number> {
 		const round = await this.database.nextRound(tournamentId);
-		// finalise tournament
-		if (round === -1) {
-			await this.finishTournament(tournamentId);
-			return round;
-		}
 		const tournament = await this.database.getTournament(tournamentId);
 		const webTourn = await this.website.getTournament(tournamentId);
 		await this.startNewRound(tournament, webTourn.url, round);

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -541,8 +541,9 @@ export class TournamentManager implements TournamentInterface {
 		return `You have reported a score of ${scorePlayer}-${scoreOpp}, ${mention}. Your opponent still needs to confirm this score.`;
 	}
 
+	// specifically only handles telling participants about a new round
+	// hosts should handle outstanding scores individually with forcescore
 	public async nextRound(tournamentId: string): Promise<number> {
-		await this.website.tieMatches(tournamentId);
 		const round = await this.database.nextRound(tournamentId);
 		// finalise tournament
 		if (round === -1) {

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -39,7 +39,7 @@ export interface TournamentInterface {
 		scoreOpp: number,
 		host?: boolean
 	): Promise<string>;
-	nextRound(tournamentId: string): Promise<number>;
+	nextRound(tournamentId: string): Promise<void>;
 	listPlayers(tournamentId: string): Promise<DiscordAttachmentOut>;
 	getPlayerDeck(tournamentId: string, playerId: string): Promise<Deck>;
 	dropPlayer(tournamentId: string, playerId: string, force?: boolean): Promise<void>;
@@ -322,13 +322,12 @@ export class TournamentManager implements TournamentInterface {
 
 	private async sendNewRoundMessage(
 		channelId: string,
-		round: number,
 		tournament: DatabaseTournament,
 		url: string,
 		bye?: string
 	): Promise<void> {
 		const role = await this.discord.getPlayerRole(tournament);
-		let message = `Round ${round} of ${tournament.name} has begun! ${this.discord.mentionRole(
+		let message = `A new round of ${tournament.name} has begun! ${this.discord.mentionRole(
 			role
 		)}\nPairings: ${url}`;
 		if (bye) {
@@ -337,16 +336,15 @@ export class TournamentManager implements TournamentInterface {
 		await this.discord.sendMessage(channelId, message);
 	}
 
-	private async startNewRound(tournament: DatabaseTournament, url: string, round: number): Promise<void> {
+	private async startNewRound(tournament: DatabaseTournament, url: string): Promise<void> {
 		const bye = await this.website.getBye(tournament.id);
-		// send round 1 message
 		const channels = tournament.publicChannels;
 		await Promise.all(
 			channels.map(async c => {
 				if (c in this.timers) {
 					await this.timers[c].abort();
 				}
-				await this.sendNewRoundMessage(c, round, tournament, url, bye);
+				await this.sendNewRoundMessage(c, tournament, url, bye);
 				this.timers[c] = await this.timer.create(
 					50,
 					c,
@@ -386,10 +384,8 @@ export class TournamentManager implements TournamentInterface {
 				await this.discord.deleteMessage(m.channelId, m.messageId);
 			})
 		);
-		// get challonge rounds with current player pool
-		const webTourn = await this.website.getTournament(tournamentId);
 		// drop pending participants
-		const droppedPlayers = await this.database.startTournament(tournamentId, webTourn.rounds);
+		const droppedPlayers = await this.database.startTournament(tournamentId);
 		await Promise.all(
 			droppedPlayers.map(async p => {
 				await this.discord.sendDirectMessage(
@@ -408,7 +404,8 @@ export class TournamentManager implements TournamentInterface {
 		// start tournament on challonge
 		await this.website.assignByes(tournamentId, tournament.players.length, tournament.byes);
 		await this.website.startTournament(tournamentId);
-		await this.startNewRound(tournament, webTourn.url, 1);
+		const webTourn = await this.website.getTournament(tournamentId);
+		await this.startNewRound(tournament, webTourn.url);
 		// drop dummy players once the tournament has started to give players with byes the win
 		await this.website.dropByes(tournamentId, tournament.byes.length);
 	}
@@ -538,12 +535,10 @@ export class TournamentManager implements TournamentInterface {
 
 	// specifically only handles telling participants about a new round
 	// hosts should handle outstanding scores individually with forcescore
-	public async nextRound(tournamentId: string): Promise<number> {
-		const round = await this.database.nextRound(tournamentId);
+	public async nextRound(tournamentId: string): Promise<void> {
 		const tournament = await this.database.getTournament(tournamentId);
 		const webTourn = await this.website.getTournament(tournamentId);
-		await this.startNewRound(tournament, webTourn.url, round);
-		return round;
+		await this.startNewRound(tournament, webTourn.url);
 	}
 
 	public async listPlayers(tournamentId: string): Promise<DiscordAttachmentOut> {

--- a/src/database/interface.ts
+++ b/src/database/interface.ts
@@ -33,8 +33,7 @@ export interface DatabaseWrapper {
 		playerId: string
 	): Promise<DatabaseTournament | undefined>;
 	removeConfirmedPlayerForce(tournamentId: string, playerId: string): Promise<DatabaseTournament | undefined>;
-	startTournament(tournamentId: string, rounds: number): Promise<string[]>;
-	nextRound(tournamentId: string): Promise<number>;
+	startTournament(tournamentId: string): Promise<string[]>;
 	finishTournament(tournamentId: string): Promise<void>;
 	synchronise(tournamentId: string, newData: SynchroniseTournament): Promise<void>;
 	registerBye(tournamentId: string, playerId: string): Promise<void>;
@@ -196,12 +195,8 @@ export class DatabaseInterface {
 		return await this.db.removeConfirmedPlayerForce(tournamentId, playerId);
 	}
 
-	public async startTournament(tournamentId: string, rounds: number): Promise<string[]> {
-		return this.db.startTournament(tournamentId, rounds);
-	}
-
-	public async nextRound(tournamentId: string): Promise<number> {
-		return await this.db.nextRound(tournamentId);
+	public async startTournament(tournamentId: string): Promise<string[]> {
+		return this.db.startTournament(tournamentId);
 	}
 
 	public async finishTournament(tournamentId: string): Promise<void> {

--- a/src/database/models/tournament.ts
+++ b/src/database/models/tournament.ts
@@ -23,8 +23,6 @@ export interface TournamentDoc extends Document {
 	}[];
 	pendingParticipants: DiscordID[];
 	byeParticipants: DiscordID[];
-	currentRound: number;
-	totalRounds: number;
 }
 
 export const TournamentSchema = new Schema({

--- a/src/database/models/tournament.ts
+++ b/src/database/models/tournament.ts
@@ -54,9 +54,7 @@ export const TournamentSchema = new Schema({
 		}
 	],
 	pendingParticipants: { type: [String], required: true, default: [] },
-	byeParticipants: { type: [String], required: true, default: [] },
-	currentRound: { type: Number, required: true, default: 0 },
-	totalRounds: { type: Number, required: true, default: 0 }
+	byeParticipants: { type: [String], required: true, default: [] }
 });
 
 export const TournamentModel = model<TournamentDoc>("Tournament", TournamentSchema);

--- a/src/database/mongoose.ts
+++ b/src/database/mongoose.ts
@@ -267,29 +267,15 @@ export class DatabaseWrapperMongoose implements DatabaseWrapper {
 	}
 
 	// Remove all pending participants and start the tournament
-	public async startTournament(tournamentId: TournamentID, rounds: number): Promise<string[]> {
+	public async startTournament(tournamentId: TournamentID): Promise<string[]> {
 		const tournament = await this.findTournament(tournamentId);
 		const removedIDs = tournament.pendingParticipants.slice(); // clone values
 		tournament.pendingParticipants = [];
 		tournament.status = "in progress";
 		tournament.currentRound = 1;
-		tournament.totalRounds = rounds;
+		tournament.totalRounds = 0; // TODO: remove totalRounds from database entirely
 		await tournament.save();
 		return removedIDs;
-	}
-
-	// Progresses tournament to the next round or returns -1 if it was already the final round
-	public async nextRound(tournamentId: TournamentID): Promise<number> {
-		const tournament = await this.findTournament(tournamentId);
-		if (tournament.status !== "in progress") {
-			throw new UserError(`Tournament ${tournamentId} is not in progress.`);
-		}
-		if (tournament.currentRound < tournament.totalRounds) {
-			++tournament.currentRound;
-			await tournament.save();
-			return tournament.currentRound;
-		}
-		return -1;
 	}
 
 	// Sets tournament status to completed

--- a/src/database/mongoose.ts
+++ b/src/database/mongoose.ts
@@ -272,8 +272,6 @@ export class DatabaseWrapperMongoose implements DatabaseWrapper {
 		const removedIDs = tournament.pendingParticipants.slice(); // clone values
 		tournament.pendingParticipants = [];
 		tournament.status = "in progress";
-		tournament.currentRound = 1;
-		tournament.totalRounds = 0; // TODO: remove totalRounds from database entirely
 		await tournament.save();
 		return removedIDs;
 	}

--- a/src/database/orm/ChallongeTournament.ts
+++ b/src/database/orm/ChallongeTournament.ts
@@ -51,14 +51,6 @@ export class ChallongeTournament extends BaseEntity {
 	@Column({ default: 0 })
 	participantLimit!: number;
 
-	/// Current round of a running tournament. Should be zero if preparing. Negatives invalid.
-	@Column({ default: 0 })
-	currentRound!: number;
-
-	/// Total rounds of Swiss. Negatives invalid.
-	@Column({ default: 0 })
-	totalRounds!: number;
-
 	/// The ORM relationship to the registration messages that identify this tournament.
 	@OneToMany(() => RegisterMessage, rm => rm.tournament, { cascade: true, onDelete: "CASCADE" })
 	registerMessages!: RegisterMessage[];

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -235,8 +235,6 @@ export class DatabaseWrapperPostgres implements DatabaseWrapper {
 			// return await improves async stack traces
 			await Promise.all(ejected.map(async p => await entityManager.remove(p)));
 			tournament.status = TournamentStatus.IPR;
-			tournament.currentRound = 1;
-			tournament.totalRounds = 0; // TODO: Remove from database entirely
 			await tournament.save();
 		});
 		return ejected.map(p => p.discordId);

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -92,12 +92,6 @@ export class WebsiteInterface {
 		await this.api.submitScore(tournamentId, winner, winnerScore, loserScore);
 	}
 
-	public async tieMatches(tournamentId: string): Promise<void> {
-		const matches = await this.api.getMatches(tournamentId);
-		// we can use either player to report a tie, the submitScore logic will make it a tie
-		await Promise.all(matches.map(async m => await this.submitScore(tournamentId, m.player1, 0, 0)));
-	}
-
 	public async finishTournament(tournamentId: string): Promise<WebsiteTournament> {
 		const tournament = await this.api.getTournament(tournamentId);
 		await this.api.finishTournament(tournamentId);

--- a/test/commandHandler.ts
+++ b/test/commandHandler.ts
@@ -156,15 +156,9 @@ describe("Tournament flow commands", function () {
 		await discord.simMessage("mc!forcescore mc_name|john won|<@john>", "forcescore2");
 		expect(discord.getResponse("forcescore2")).to.equal("Must provide score in format `#-#` e.g. `2-1`.");
 	});
-	it("Next round - normal", async function () {
+	it("Next round", async function () {
 		await discord.simMessage("mc!round mc_name", "round1");
-		expect(discord.getResponse("round1")).to.equal("Tournament mc_name successfully progressed to round 2.");
-	});
-	it("Next round - final", async function () {
-		await discord.simMessage("mc!round mc_final", "round2");
-		expect(discord.getResponse("round2")).to.equal(
-			"Tournament mc_final successfully progressed past final round and completed."
-		);
+		expect(discord.getResponse("round1")).to.equal("New round successfully started for Tournament mc_name.");
 	});
 });
 describe("Misc tournament commands", function () {

--- a/test/database.ts
+++ b/test/database.ts
@@ -142,13 +142,8 @@ describe("Player registration", function () {
 
 describe("Tournament flow", function () {
 	it("startTournament", async function () {
-		const droppedPlayers = await database.startTournament("mc_test", 3);
+		const droppedPlayers = await database.startTournament("mc_test");
 		expect(droppedPlayers.length).to.equal(0);
-	});
-
-	it("nextRound", async function () {
-		const round = await database.nextRound("mc_test");
-		expect(round).to.equal(2);
 	});
 
 	it("finishTournament", async function () {

--- a/test/mocks/tournament.ts
+++ b/test/mocks/tournament.ts
@@ -74,11 +74,8 @@ export class TournamentMock implements TournamentInterface {
 		return "For more detail, test the tournament handler!";
 	}
 
-	public async nextRound(tournamentId: string): Promise<number> {
-		if (tournamentId === "mc_final") {
-			return -1;
-		}
-		return 2;
+	public async nextRound(): Promise<void> {
+		return;
 	}
 
 	public async listPlayers(tournamentId: string): Promise<DiscordAttachmentOut> {

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -87,7 +87,7 @@ describe("Tournament flow commands", function () {
 		await expect(tournament.startTournament("smallTournament")).to.be.rejectedWith(UserError);
 	});
 	it("Cancel tournament", async function () {
-		await tournament.cancelTournament("mc_tourn1");
+		await tournament.finishTournament("mc_tourn1", true);
 		expect(discord.getResponse("channel1")).to.equal(
 			"Tournament 1 has been cancelled. Thank you all for playing! <@&role>\nResults: https://example.com/url"
 		);

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -131,8 +131,7 @@ describe("Tournament flow commands", function () {
 		expect(response).to.equal("");
 	});
 	it("Next round", async function () {
-		const round = await tournament.nextRound("mc_tourn1");
-		expect(round).to.equal(2);
+		await tournament.nextRound("mc_tourn1");
 		expect(discord.getResponse("channel1")).to.equal("Time left in the round: `50:00`"); // new round means new timer
 	});
 });

--- a/test/website.ts
+++ b/test/website.ts
@@ -74,10 +74,6 @@ describe("Tournament flow commands", function () {
 		await expect(website.submitScore("mc_test", 1, 2, 1)).to.not.be.rejected;
 	});
 
-	it("tieMatches", async function () {
-		await expect(website.tieMatches("mc_test")).to.not.be.rejected;
-	});
-
 	it("finishTournament", async function () {
 		const tournament = await website.finishTournament("mc_test");
 		expect(tournament).to.deep.equal({


### PR DESCRIPTION
This feature caused issues because Challonge would move onto the next round when all scores were submitted. Now instead similar behaviour can be manually simulated by hosts using `mc!forcescore` and `mc!round` only sends a message and starts the timer.