### PR TITLE
Enumerate DUMMY players on Challonge end

### DIFF
--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -629,7 +629,9 @@ export class TournamentManager implements TournamentInterface {
 		await this.database.synchronise(tournamentId, {
 			name: tournamentData.name,
 			description: tournamentData.desc,
-			players: tournamentData.players.map(p => p.challongeId)
+			players: tournamentData.players.map(p => {
+				return { challongeId: p.challongeId, discordId: p.discordId };
+			})
 		});
 	}
 

--- a/src/database/interface.ts
+++ b/src/database/interface.ts
@@ -70,7 +70,7 @@ export interface DatabaseTournament {
 export interface SynchroniseTournament {
 	name: string;
 	description: string;
-	players: number[];
+	players: { challongeId: number; discordId: string }[];
 }
 
 export class DatabaseInterface {

--- a/src/database/mongoose.ts
+++ b/src/database/mongoose.ts
@@ -319,12 +319,12 @@ export class DatabaseWrapperMongoose implements DatabaseWrapper {
 		const tournament = await this.findTournament(tournamentId);
 		// insert new players
 		for (const newPlayer of newDoc.players) {
-			const player = tournament.confirmedParticipants.find(p => p.challongeId === newPlayer);
+			const player = tournament.confirmedParticipants.find(p => p.challongeId === newPlayer.challongeId);
 			// if a player already exist, challonge doesn't have any info that should have changed
 			if (!player) {
 				tournament.confirmedParticipants.push({
-					challongeId: newPlayer,
-					discordId: "DUMMY",
+					challongeId: newPlayer.challongeId,
+					discordId: newPlayer.discordId,
 					deck: "ydke://!!!" // blank deck
 				});
 			}

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -273,12 +273,12 @@ export class DatabaseWrapperPostgres implements DatabaseWrapper {
 	async synchronise(tournamentId: string, newData: SynchroniseTournament): Promise<void> {
 		const tournament = await this.findTournament(tournamentId);
 		for (const newPlayer of newData.players) {
-			let player = tournament.confirmed.find(p => p.challongeId === newPlayer);
+			let player = tournament.confirmed.find(p => p.challongeId === newPlayer.challongeId);
 			// if a player already exists, Challonge doesn't have any info that should have changed
 			if (!player) {
 				player = new ConfirmedParticipant();
-				player.challongeId = newPlayer;
-				player.discordId = "DUMMY";
+				player.challongeId = newPlayer.challongeId;
+				player.discordId = newPlayer.discordId;
 				player.deck = "ydke://!!!";
 				tournament.confirmed.push(player);
 			}

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -116,7 +116,7 @@ export class WebsiteInterface {
 		const numByes = playersToBye.length - (numPlayers % 2); // if odd no. of players, 1 can get the natural bye
 		const byePlayers = [];
 		for (let i = 0; i < numByes; i++) {
-			byePlayers.push(await this.registerPlayer(tournamentId, `Round 1 Bye #${i + 1}`, `DUMMY${i}`));
+			byePlayers.push(await this.registerPlayer(tournamentId, `Round 1 Bye #${i + 1}`, `BYE${i}`));
 		}
 		const maxSeed = numPlayers + numByes; // new no. of players
 		const players = await this.api.getPlayers(tournamentId);
@@ -165,7 +165,7 @@ export class WebsiteInterface {
 	public async dropByes(tournamentId: string, numByes: number): Promise<void> {
 		const players = await this.api.getPlayers(tournamentId);
 		for (let i = 0; i < numByes; i++) {
-			const player = players.find(p => p.discordId === `DUMMY${i}`);
+			const player = players.find(p => p.discordId === `BYE${i}`);
 			// could assert non-null here cuz we made these players
 			// but this is simple enough and handles them being manually dropped
 			if (player) {

--- a/test/database.ts
+++ b/test/database.ts
@@ -202,7 +202,7 @@ describe("Misc functions", function () {
 			database.synchronise("mc_test", {
 				name: "newName",
 				description: "newDesc",
-				players: [1]
+				players: [{ challongeId: 1, discordId: "DUMMY0" }]
 			})
 		).to.not.be.rejected;
 	});


### PR DESCRIPTION
Will allow distinct IDs for synchronised players, allowing smoother testing of features that involve multiple players