### PR TITLE
Fix Postgres arrays being dropped on boot

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,12 +7,24 @@
 		{
 			"type": "node",
 			"request": "launch",
-			"name": "Launch Emcee",
+			"name": "Debug Emcee",
 			"skipFiles": ["<node_internals>/**"],
 			"program": "${workspaceFolder}/dist",
 			"args": ["--enable-source-maps"],
 			"preLaunchTask": "npm: build",
-			"outFiles": ["${workspaceFolder}/dist/**/*.js"]
+			"outFiles": ["${workspaceFolder}/dist/**/*.js"],
+			"outputCapture": "std"
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Debug Emcee (integrated terminal)",
+			"skipFiles": ["<node_internals>/**"],
+			"program": "${workspaceFolder}/dist",
+			"args": ["--enable-source-maps"],
+			"preLaunchTask": "npm: build",
+			"outFiles": ["${workspaceFolder}/dist/**/*.js"],
+			"console": "integratedTerminal"
 		},
 		{
 			"type": "node",

--- a/src/database/orm/ChallongeTournament.ts
+++ b/src/database/orm/ChallongeTournament.ts
@@ -32,15 +32,19 @@ export class ChallongeTournament extends BaseEntity {
 
 	/// An array of Discord user snowflakes. Whenever hosts are queried, the rest
 	/// of the tournament information is wanted anyway. Should be distinct.
-	@Column("varchar", { length: 20, array: true, default: "{}" })
+	// @Column("varchar", { length: 20, array: true, default: "{}" })
+	// https://github.com/typeorm/typeorm/issues/6990
+	@Column("json", { default: [] })
 	hosts!: string[];
 
 	/// An array of Discord channel snowflakes. Should be distinct.
-	@Column("varchar", { length: 20, array: true, default: "{}" })
+	// @Column("varchar", { length: 20, array: true, default: "{}" })
+	@Column("json", { default: [] })
 	publicChannels!: string[];
 
 	/// An array of Discord channel snowflakes. Should be distinct.
-	@Column("varchar", { length: 20, array: true, default: "{}" })
+	// @Column("varchar", { length: 20, array: true, default: "{}" })
+	@Column("json", { default: [] })
 	privateChannels!: string[];
 
 	/// Simple state progression in the listed order above.

--- a/src/database/orm/index.ts
+++ b/src/database/orm/index.ts
@@ -12,7 +12,7 @@ export async function initializeConnection(postgresqlUrl: string): Promise<void>
 		type: "postgres",
 		url: postgresqlUrl,
 		entities: [ChallongeTournament, ConfirmedParticipant, Countdown, Participant, RegisterMessage],
-		logging: true,
+		logging: "all",
 		logger: "file", // TODO: not ideal, synchronous, file location cannot be changed, but custom logger is broken
 		synchronize: true // TODO: process.env.NODE_ENV === "development" and investigate migrations
 	});


### PR DESCRIPTION
Due to typeorm/typeorm#6990, in synchronize mode arrays are dropped and recreated. We work around this by using the json data type