### PR TITLE
Docker: use staged builds and downgrade to node user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,5 @@ dist
 .vscode/settings.json
 
 */auth.json
-dbs/
+
+*.cdb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 ARG NODE_VERSION=14-buster
 FROM node:${NODE_VERSION} as build
-USER node
 WORKDIR /app
-COPY package*.json ./
-RUN yarn
+COPY package*.json yarn.lock ./
+RUN yarn --prod
 COPY . .
 RUN yarn build
 
@@ -11,7 +10,7 @@ FROM node:${NODE_VERSION}
 WORKDIR /app
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dbs ./dbs
-COPY --from=build /app/package*.json ./
+COPY --from=build /app/package*.json /app/yarn.lock ./
 COPY --from=build /app/dist ./
 RUN chown -R node:node dbs
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 ARG NODE_VERSION=14-buster
 FROM node:${NODE_VERSION} as build
+USER node
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN yarn
 COPY . .
-RUN npm run build
+RUN yarn build
 
 FROM node:${NODE_VERSION}
 WORKDIR /app
@@ -12,6 +13,6 @@ COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dbs ./dbs
 COPY --from=build /app/package*.json ./
 COPY --from=build /app/dist ./
-RUN mkdir logs && touch ormlogs.log && chown -R node:node dbs logs ormlogs.log
+RUN chown -R node:node dbs
 USER node
 CMD ["node", "--enable-source-maps", "."]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
-FROM node:14-buster
+ARG NODE_VERSION=14-buster
+FROM node:${NODE_VERSION} as build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
-CMD ["node", "--enable-source-maps", "dist"]
+
+FROM node:${NODE_VERSION}
+WORKDIR /app
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dbs ./dbs
+COPY --from=build /app/package*.json ./
+COPY --from=build /app/dist ./
+RUN mkdir logs && touch ormlogs.log && chown -R node:node dbs logs ormlogs.log
+USER node
+CMD ["node", "--enable-source-maps", "."]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 ARG NODE_VERSION=14-buster
-FROM node:${NODE_VERSION} as build
+FROM node:${NODE_VERSION} as base
 WORKDIR /app
 COPY package*.json yarn.lock ./
 RUN yarn --prod
+
+FROM base as build
+RUN yarn
 COPY . .
 RUN yarn build
 
-FROM node:${NODE_VERSION}
+FROM base
 WORKDIR /app
-COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/dbs ./dbs
-COPY --from=build /app/package*.json /app/yarn.lock ./
-COPY --from=build /app/dist ./
-RUN chown -R node:node dbs
+COPY --from=build /app/dist .
+COPY --chown=node:node dbs/ ./dbs
 USER node
 CMD ["node", "--enable-source-maps", "."]


### PR DESCRIPTION
This reduces the size of the final image by only installing production dependencies and copying in the transpiled code, rather than just running from the build container. We also switch to the yarn ecosystem.

The gains of a smaller final image at the cost of the build process will only be realized when we start deploying to a registry.