### PR TITLE
Open source community setup

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Community Impact Guidelines were inspired by 
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available 
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+[bastionbotdev@gmail.com](mailto:bastionbotdev@gmail.com).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -119,11 +119,11 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
 [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
 
-Community Impact Guidelines were inspired by 
+Community Impact Guidelines were inspired by
 [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
 For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available 
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
 at [https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,9 +3,9 @@
 Emcee is under heavy development but we welcome first-time contributors!
 There are many ways to contribute:
 
-- [report a bug or documentation problem](https://github.com/AlphaKretin/emcee-tournament-bot/issues)
-- [submit a pull request](https://github.com/AlphaKretin/emcee-tournament-bot/pulls) to fix a bug or implement a feature you want to see
-- [join the community on Discord](https://discord.gg/GrMGspZ)
+- [Report a bug or documentation problem](https://github.com/AlphaKretin/emcee-tournament-bot/issues)
+- [Submit a pull request](https://github.com/AlphaKretin/emcee-tournament-bot/pulls) to fix a bug or implement a feature you want to see
+- [Join the community on Discord](https://discord.gg/GrMGspZ)
 
 More information on the software architecture of this project and how to run are
 under construction but should be in the main README for now.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to Emcee
+
+This article is a stub.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,11 @@
 # Contributing to Emcee
 
-This article is a stub.
+Emcee is under heavy development but we welcome first-time contributors!
+There are many ways to contribute:
+
+- [report a bug or documentation problem](https://github.com/AlphaKretin/emcee-tournament-bot/issues)
+- [submit a pull request](https://github.com/AlphaKretin/emcee-tournament-bot/pulls) to fix a bug or implement a feature you want to see
+- [join the community on Discord](https://discord.gg/GrMGspZ)
+
+More information on the software architecture of this project and how to run are
+under construction but should be in the main README for now.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: alphakretinbots
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,77 @@
+---
+name: 🐛 Bug report
+about: Report a reproducible bug or regression.
+title: ""
+labels: bug
+assignees: ""
+---
+
+<!--
+  Please follow the template.  If you don't, your issue may be closed.
+  Make sure to search existing issues first to avoid creating duplicates.
+  Contributing guidelines: https://github.com/AlphaKretin/emcee-tournament-bot/master/.github/CONTRIBUTING.md
+  Code of conduct: https://github.com/AlphaKretin/emcee-tournament-bot/master/.github/CODE_OF_CONDUCT.md
+
+  Have a question?  This is not the right place for general support or feature requests.
+  Instead, join our Discord server and send inquires that way ➡️ https://discord.gg/GrMGspZ
+-->
+
+## Expected behaviour
+
+<!--
+  A clear and concise description of what you expected to happen.
+-->
+
+
+### Actual behaviour
+
+<!--
+  A clear and concise description of what actually happened.
+-->
+
+
+### Steps to reproduce
+
+<!--
+  Your bug will be investigated much faster if we can replicate your problem easily.
+  Issues without reproduction steps may be closed as not actionable.
+-->
+
+1.
+2.
+
+
+### My environment
+
+<!--
+  Please add any relevant dependencies to this table at the end.
+-->
+
+| Dependency                       | Version  |
+| ---                              | ---      |
+| Operating System                 |          |
+| Node.js version if not in Docker | vX.Y.ZZZ | <!-- run `node -v` to obtain this -->
+
+
+### Additional context
+
+<!--
+  Add any other context about the bug report here.
+-->
+
+
+### Are you willing to resolve this issue by submitting a pull request?
+
+<!--
+  First-time contributors are welcome! 😊
+-->
+
+- [ ] Yes, I have the time, and I know how to start.
+- [ ] Yes, I have the time, but I don't know how to start. I would need guidance.
+- [ ] No, I don't have the time, although I believe I could do it if I had the time...
+- [ ] No, I don't have the time and I wouldn't even know how to start.
+
+
+<!--
+  👋 Have a great day and thank you for the bug report!
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Help and support, feature requests
+    url: https://discord.gg/GrMGspZ
+    about: Please ask questions on our Discord server. This issue tracker is only for formatted reports.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: 🔓 Potential security flaw
+    url: https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/SECURITY.md
+    about: Please do not open a public issue. Instead, report it according to the security policy.
   - name: ❓ Help and support, feature requests
     url: https://discord.gg/GrMGspZ
     about: Please ask questions on our Discord server. This issue tracker is only for formatted reports.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,62 @@
+---
+name: 📝 Documentation problem
+about: Documentation is unclear or otherwise insufficient.
+title: ""
+labels: documentation
+assignees: ""
+---
+
+<!--
+  Please follow the template.  If you don't, your issue may be closed.
+  Make sure to search existing issues first to avoid creating duplicates.
+  Contributing guidelines: https://github.com/AlphaKretin/emcee-tournament-bot/master/.github/CONTRIBUTING.md
+  Code of conduct: https://github.com/AlphaKretin/emcee-tournament-bot/master/.github/CODE_OF_CONDUCT.md
+
+
+  Have a question?  This is not the right place for general support or feature requests.
+  Instead, join our Discord server and send inquires that way ➡️ https://discord.gg/GrMGspZ
+-->
+
+### What was unclear or otherwise insufficient?
+
+<!--
+  If relevant, please be clear about the documentation file,
+  as well as the location within the file.  Link to the documentation
+  in the repository.
+
+  If the page does not exist, please be clear why a new documentation
+  section is needed.
+-->
+
+
+### Recommended fix
+
+<!--
+  How should we fix this documentation issue?
+
+  Should we add examples, clarify the language, or drop the page entirely?
+-->
+
+
+### Additional context
+
+<!--
+  Add any other context about the documentation issue here.
+-->
+
+
+### Are you willing to resolve this issue by submitting a pull request?
+
+<!--
+  First-time contributors are welcome! 😊
+-->
+
+- [ ] Yes, I have the time, and I know how to start.
+- [ ] Yes, I have the time, but I don't know how to start. I would need guidance.
+- [ ] No, I don't have the time, although I believe I could do it if I had the time...
+- [ ] No, I don't have the time and I wouldn't even know how to start.
+
+
+<!--
+  👋 Have a great day and thank you for the report!
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@ Fixes issue #
 
 ## Checklist
 
--   [ ] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/master/.github/CONTRIBUTING.md).
+- [ ] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/master/.github/CONTRIBUTING.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+<!--
+  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
+-->
+
+## Description
+
+Fixes issue #
+
+## Checklist
+
+-   [ ] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/master/.github/CONTRIBUTING.md).

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,4 +4,26 @@ Only the latest published release and the HEAD of the default branch are support
 
 ## Reporting a vulnerability
 
-Please report suspected security vulnerabilities to AlphaKretin#7990 via direct message on Discord or email. We will acknowledge receipt of your report as soon as possible and let you know the next steps.
+Please report suspected security vulnerabilities to [bastionbotdev@gmail.com](mailto:bastionbotdev@gmail.com).
+You can also send your reports to `AlphaKretin#7990` via direct message on Discord,
+but please do not send a friend request; join our [Discord server](https://discord.gg/GrMGspZ)
+if direct messages don't go through.
+
+We will acknowledge receipt of your report as soon as possible and let you know the next steps.
+
+Examples (nonexhaustive):
+
+- privilege escalation
+- remote code execution
+- SQL injection
+
+## Report format
+
+This is similar to regular bug reports.
+
+1. Vulnerability type
+1. Expected behaviour
+1. Actual behaviour
+1. Steps to reproduce
+1. Your environment
+1. Any additional context

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,7 @@
+# Security policy
+
+Only the latest published release and the HEAD of the default branch are supported.
+
+## Reporting a vulnerability
+
+Please report suspected security vulnerabilities to AlphaKretin#7990 via direct message on Discord or email. We will acknowledge receipt of your report as soon as possible and let you know the next steps.


### PR DESCRIPTION
This was ready yesterday but it's not done yet because I'm not sure of what security policy to set, email contacts, and also of course, the contributing guide is a stub. I based the templates off of TypeORM because they looked really good. Security policy could be linked in the issue template config too. Contributing guide aside this could be reused across other related projects.