### PR TITLE
List: Add handling for empty list

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -31,7 +31,11 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		await msg.reply(`\`\`\`\n${list}\`\`\``);
+		if (list.length === 0) {
+			await msg.reply("There are no open tournaments you have access to!");
+		} else {
+			await msg.reply(`\`\`\`\n${list}\`\`\``);
+		}
 	}
 };
 


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

Adds a response when the list of tournaments is empty. No tests are included because the `list` command is not yet under the new test stucture.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
