### PR TITLE
Send Direct Messages to players about their opponent on a new round

### DIFF
--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -421,8 +421,6 @@ export class TournamentManager implements TournamentInterface {
 		const players = await this.website.getPlayers(tournament.id);
 		await Promise.all(
 			matches.map(async match => {
-				// TODO: not finding this player is an error path, but a pretty bad one at this stage
-				// not entirely sure how to handle it
 				const player1 = players.find(p => p.challongeId === match.player1)?.discordId;
 				const player2 = players.find(p => p.challongeId === match.player2)?.discordId;
 				if (player1 && player2) {
@@ -446,6 +444,13 @@ export class TournamentManager implements TournamentInterface {
 						}`;
 						await this.discord.sendDirectMessage(player2, message);
 					}
+				} else {
+					// This error occuring is an issue on Challonge's end
+					logger.warn(
+						new Error(
+							`Challonge IDs ${player1} and/or ${player2} found in match ${match.matchId} but not the player list.`
+						)
+					);
 				}
 			})
 		);

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -426,25 +426,33 @@ export class TournamentManager implements TournamentInterface {
 				const player1 = players.find(p => p.challongeId === match.player1)?.discordId;
 				const player2 = players.find(p => p.challongeId === match.player2)?.discordId;
 				if (player1 && player2) {
-					await this.discord.sendDirectMessage(
-						player1,
-						`A new round of ${tournament.name} has begun! Your opponent is ${this.discord.mentionUser(
-							player2
-						)} (${this.discord.getUsername(player2)}).`
-					);
-					await this.discord.sendDirectMessage(
-						player2,
-						`A new round of ${tournament.name} has begun! Your opponent is ${this.discord.mentionUser(
-							player1
-						)} (${this.discord.getUsername(player1)}).`
-					);
+					const mention1 = this.discord.mentionUser(player1);
+					const mention2 = this.discord.mentionUser(player2);
+					const isBye1 = player1 === mention1; // if not bye, ID will be valid and resolve to a mention
+					const isBye2 = player2 === mention2;
+					if (!isBye1) {
+						const message = `A new round of ${tournament.name} has begun! ${
+							isBye2
+								? "You have a bye for this round."
+								: `Your opponent is ${mention2} (${this.discord.getUsername(player2)}).`
+						}`;
+						await this.discord.sendDirectMessage(player1, message);
+					}
+					if (!isBye2) {
+						const message = `A new round of ${tournament.name} has begun! ${
+							isBye1
+								? "You have a bye for this round."
+								: `Your opponent is ${mention1} (${this.discord.getUsername(player1)}).`
+						}`;
+						await this.discord.sendDirectMessage(player2, message);
+					}
 				}
 			})
 		);
 		if (bye) {
 			await this.discord.sendDirectMessage(
 				bye,
-				`A new round of ${tournament.name} has begun! You have the bye for this round.`
+				`A new round of ${tournament.name} has begun! You have a bye for this round.`
 			);
 		}
 	}

--- a/src/commands/round.ts
+++ b/src/commands/round.ts
@@ -7,7 +7,7 @@ const command: CommandDefinition = {
 	name: "round",
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
-		const [id] = args;
+		const [id, skip] = args; // second is optional and may be undefined
 		await support.tournamentManager.authenticateHost(id, msg);
 		logger.verbose(
 			JSON.stringify({
@@ -19,7 +19,7 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		await support.tournamentManager.nextRound(id);
+		await support.tournamentManager.nextRound(id, !!skip);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channelId,

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -85,8 +85,16 @@ export class WebsiteInterface {
 		return bye?.discordId;
 	}
 
+	public async getMatches(tournamentId: string): Promise<WebsiteMatch[]> {
+		return await this.api.getMatches(tournamentId);
+	}
+
 	public async findMatch(tournamentId: string, playerId: number): Promise<WebsiteMatch | undefined> {
 		return await this.api.getMatchWithPlayer(tournamentId, playerId);
+	}
+
+	public async getPlayers(tournamentId: string): Promise<WebsitePlayer[]> {
+		return await this.api.getPlayers(tournamentId);
 	}
 
 	public async removePlayer(tournamentId: string, playerId: number): Promise<void> {


### PR DESCRIPTION
## Description

Adds new functionality that upon starting a new round will message each player with the contact details for their opponent, to expedite arranging matches. This also informs the bye privately in addition to the existing public notification. 

- [x] To consider before merging: should we remove the public bye notification?
- [x] Detect if the opponent is a bye dummy player and change the message, as well as don't send the dummy a message that will fail.
- [x] Handle failure to find challonge player with given ID.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
