### PR TITLE
Add guides for host commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,6 @@ FROM base
 WORKDIR /app
 COPY --from=build /app/dist .
 COPY --chown=node:node dbs/ ./dbs
+COPY guides/ ./guides
 USER node
 CMD ["node", "--enable-source-maps", "--unhandled-rejections=strict", "."]

--- a/guides/create.template.md
+++ b/guides/create.template.md
@@ -1,0 +1,17 @@
+Thanks for hosting your tournament with Emcee! To get started, you'll want to add some announcement channels.
+A public announcement channel will be where players in your tournament will see signups and new rounds. To add the current channel as a public channel, use this command.
+`mc!addchannel {}`
+To add a different channel as a public announcement channel, mention it. So for a channel called #pairings, use this command.
+`mc!addchannel {}|public|#pairings`
+A private announcement channel will be where hosts can see the decks players submit. To add the current channel as a private channel, use this command.
+`mc!addchannel {}|private`
+You can also mention private channels. For a channel called #decks, use this command.
+`mc!addchannel {}|private|#decks`
+If you want to change the name or description of the tournament, you can use this command.
+`mc!update {}|New Name|A new description`
+To add another user as a host so they can manage the tournament, you'll mention them. Be careful, only give this privilege to people you'd trust as moderators. For the user Sample, you'd use this command.
+`mc!addhost {}|@Sample`
+If you need to take those privileges away, you can use this command.
+`mc!removehost {}|@Sample`
+When you're ready to open signups for your tournament, you can use this command, and after that we'll send details to private channels on how to proceed.
+`mc!open {}`

--- a/guides/create.template.md
+++ b/guides/create.template.md
@@ -1,17 +1,27 @@
-Thanks for hosting your tournament with Emcee! To get started, you'll want to add some announcement channels.
-A public announcement channel will be where players in your tournament will see signups and new rounds. To add the current channel as a public channel, use this command.
-`mc!addchannel {}`
-To add a different channel as a public announcement channel, mention it. So for a channel called #pairings, use this command.
-`mc!addchannel {}|public|#pairings`
-A private announcement channel will be where hosts can see the decks players submit. To add the current channel as a private channel, use this command.
-`mc!addchannel {}|private`
-You can also mention private channels. For a channel called #decks, use this command.
-`mc!addchannel {}|private|#decks`
-If you want to change the name or description of the tournament, you can use this command.
-`mc!update {}|New Name|A new description`
-To add another user as a host so they can manage the tournament, you'll mention them. Be careful, only give this privilege to people you'd trust as moderators. For the user Sample, you'd use this command.
-`mc!addhost {}|@Sample`
-If you need to take those privileges away, you can use this command.
-`mc!removehost {}|@Sample`
-When you're ready to open signups for your tournament, you can use this command, and after that we'll send details to private channels on how to proceed.
-`mc!open {}`
+**Add channels**
+You need a public channel to start signups.
+Public channels are used for signups and pairings.
+```
+mc!addchannel {}|public|#pairings```
+Private channels are used for player decks.
+```
+mc!addchannel {}|private|#decks```
+You remove channels if you make a mistake.
+```
+mc!removechannel {}|public|#pairings```
+If you don't mention a channel, it will add the current channel.
+**Add hosts**
+Hosts have all the same permissions you do.
+Trust them like you would a moderator.
+```
+mc!addhost {}|@User
+mc!removehost {}|@User```
+**Change info**
+You can change the name and description.
+```
+mc!update {}|New Name|A new description```
+**Open signups**
+This will start the next stage of the tournament.
+Further details will be sent to private channels.
+```
+mc!open {}```

--- a/guides/open.template.md
+++ b/guides/open.template.md
@@ -1,13 +1,30 @@
-Now that you've started your tournament, players can start signing up.
-If you need to remove a player from the tournament, because they're unwilling or unable to drop themself, you can mention them. So for the player Sample, you'd use this command.
-`mc!forcedrop {}|@Sample`
-You can give players round 1 byes, so that they don't duel anyone and automatically get one win in the first round. For this, you mention them. So for the player Sample, you'd use this command.
-`mc!addbye {}|@Sample`
-If you made a mistake and need to remove that bye, you can use this command.
-`mc!removebye {}|@Sample`
-If you need to see a player's deck, you can mention them. So for the player Sample, you'd use this command.
-`mc!deck {}|@Sample`
-There are three commands that give a breakdown of the players and decks in the tournament, all in CSV format. `players` lists each player and the archetype of their deck, `pie` lists the number of times each archetype has been played, and `dump` lists each player and their decklist.
-These commands are `mc!players {}`, `mc!pie {}` and `mc!dump {}`
-Once all the players you want are signed up, and you're ready to start playing, you can use this command, and after that we'll send more details to private channels on how to proceed.
-`mc!start {}`
+Players can sign up now.
+**Drop players**
+Players can drop themselves.
+If you need, you can also drop players.
+```
+mc!forcedrop {}|@User```
+**Add bye**
+Players with a bye don't play in round 1.
+This gives them a free win.
+```
+mc!addbye {}|@User
+mc!removebye {}|@Sample```
+**View decks**
+You can view a single player's deck.
+```
+mc!deck {}|@User```
+You can download a CSV file of all players with their deck's archetype.
+```
+mc!players {}```
+You can download a CSV file of all players with their deck lists.
+```
+mc!dump {}```
+You can download a CSV file of how many decks have each archetype.
+```
+mc!pie {}```
+**Start tournament**
+This will start the first round of play.
+Further details will be sent to private channels.
+```
+mc!start {}```

--- a/guides/open.template.md
+++ b/guides/open.template.md
@@ -1,0 +1,13 @@
+Now that you've started your tournament, players can start signing up.
+If you need to remove a player from the tournament, because they're unwilling or unable to drop themself, you can mention them. So for the player Sample, you'd use this command.
+`mc!forcedrop {}|@Sample`
+You can give players round 1 byes, so that they don't duel anyone and automatically get one win in the first round. For this, you mention them. So for the player Sample, you'd use this command.
+`mc!addbye {}|@Sample`
+If you made a mistake and need to remove that bye, you can use this command.
+`mc!removebye {}|@Sample`
+If you need to see a player's deck, you can mention them. So for the player Sample, you'd use this command.
+`mc!deck {}|@Sample`
+There are three commands that give a breakdown of the players and decks in the tournament, all in CSV format. `players` lists each player and the archetype of their deck, `pie` lists the number of times each archetype has been played, and `dump` lists each player and their decklist.
+These commands are `mc!players {}`, `mc!pie {}` and `mc!dump {}`
+Once all the players you want are signed up, and you're ready to start playing, you can use this command, and after that we'll send more details to private channels on how to proceed.
+`mc!start {}`

--- a/guides/player.template.md
+++ b/guides/player.template.md
@@ -1,0 +1,13 @@
+This tournament uses player score reporting. At the end of a match, both you and your opponent will have to submit your score.
+If you won 2-0, copy and paste this command:
+`mc!score {}|2-0\`
+If you won 2-1, copy and paste this command:
+`mc!score {}|2-1\`
+If you lost 0-2, copy and paste this command:
+`mc!score {}|0-2\`
+If you lose 1-2, copy and paste this command:
+`mc!score {}|0-2\`
+If your scores don't match, both of you will need to try again. If you can't agree on what the score was, ask a host to intervene. You will need to send them replays of the games.
+If you want to drop from the tournament and stop playing, copy and paste this command:
+`mc!drop {}`
+"Please be careful, as using this command will **drop you from the tournament permanently**!

--- a/guides/player.template.md
+++ b/guides/player.template.md
@@ -1,13 +1,20 @@
-This tournament uses player score reporting. At the end of a match, both you and your opponent will have to submit your score.
+**Report scores**
+You report your own scores.
+Both you and opponent need to report.
 If you won 2-0, copy and paste this command:
-`mc!score {}|2-0\`
+```
+mc!score {}|2-0```
 If you won 2-1, copy and paste this command:
-`mc!score {}|2-1\`
+```
+mc!score {}|2-1```
 If you lost 0-2, copy and paste this command:
-`mc!score {}|0-2\`
-If you lose 1-2, copy and paste this command:
-`mc!score {}|0-2\`
-If your scores don't match, both of you will need to try again. If you can't agree on what the score was, ask a host to intervene. You will need to send them replays of the games.
-If you want to drop from the tournament and stop playing, copy and paste this command:
-`mc!drop {}`
-"Please be careful, as using this command will **drop you from the tournament permanently**!
+```
+mc!score {}|0-2```
+If you lost 1-2, copy and paste this command:
+```
+mc!score {}|0-2```
+**Drop**
+If you want to stop playing.
+Be careful, this **removes you from the tournament permanently**.
+```
+mc!drop {}```

--- a/guides/start.template.md
+++ b/guides/start.template.md
@@ -1,9 +1,16 @@
-Now that the first round of the tournament has begun, players are responsible for reporting their own scores.
-However, if they can't, because they have trouble with the command or don't agree on who won, you can step in by mentioning the winner. If the player Sample won with a score of 2-1, use this command.
-`mc!forcescore {}|2-1|@Sample`
-Once you've got all the scores for the round and Challonge has generated the next pairings, you can start the timer for the next round at your leisure with this command.
-`mc!round {}`
-When all the rounds are complete and the tournament is finished, you can end it with this command.
-`mc!finish {}`
-If you need to stop the tournament early, and you can't finish it properly because you don't have all the scores, you can cancel it with this command. Be careful, because this will **end the tournament permanently**.
-`mc!cancel {}`
+**Report score**
+Players report their own score.
+If you need, you can also report scores. Mention the winner.
+```
+mc!forcescore {}|2-1|@Winner```
+**Start round**
+This doesn't control Challonge. Make sure you have all scores and the bracket is updated.
+```
+mc!round {}```
+**Finish tournament**
+After all scores for all rounds are submitted.
+```
+mc!finish {}```
+If you need to stop early, you can cancel.
+```
+mc!cancel {}```

--- a/guides/start.template.md
+++ b/guides/start.template.md
@@ -1,0 +1,9 @@
+Now that the first round of the tournament has begun, players are responsible for reporting their own scores.
+However, if they can't, because they have trouble with the command or don't agree on who won, you can step in by mentioning the winner. If the player Sample won with a score of 2-1, use this command.
+`mc!forcescore {}|2-1|@Sample`
+Once you've got all the scores for the round and Challonge has generated the next pairings, you can start the timer for the next round at your leisure with this command.
+`mc!round {}`
+When all the rounds are complete and the tournament is finished, you can end it with this command.
+`mc!finish {}`
+If you need to stop the tournament early, and you can't finish it properly because you don't have all the scores, you can cancel it with this command. Be careful, because this will **end the tournament permanently**.
+`mc!cancel {}`

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -155,7 +155,7 @@ export class TournamentManager implements TournamentInterface {
 	}
 
 	private generateHostGuideCreate(tournamentId: string): string {
-		return (
+		const message =
 			"Thanks for hosting your tournament with Emcee! To get started, you'll want to add some announcement channels.\n" +
 			`A public announcement channel will be where players in your tournament will see signups and new rounds. To add the current channel as a public channel, use this command.\n\`mc!addchannel ${tournamentId}\`\n` +
 			`To add a different channel as a public announcement channel, mention it. So for a channel called #pairings, use this command.\n\`mc!addchannel ${tournamentId}|public|#pairings\`\n` +
@@ -165,8 +165,8 @@ export class TournamentManager implements TournamentInterface {
 			`To add another user as a host so they can manage the tournament, you'll mention them. Be careful, only give this privilege to people you'd trust as moderators. For the user Sample, you'd use this command\n` +
 			`\`mc!addhost ${tournamentId}|@Sample\`\n` +
 			`If you need to take those privileges away, you can use this command.\n\`mc!removehost ${tournamentId}|@Sample\`\n` +
-			`When you're ready to open signups for your tournament, you can use this command, and after that we'll send details to private channels on how to proceed.\n\`mc!open ${tournamentId}\``
-		);
+			`When you're ready to open signups for your tournament, you can use this command, and after that we'll send details to private channels on how to proceed.\n\`mc!open ${tournamentId}\``;
+		return message;
 	}
 
 	public async createTournament(
@@ -449,18 +449,19 @@ export class TournamentManager implements TournamentInterface {
 	}
 
 	private async sendPlayerGuide(channelId: string, tournamentId: string): Promise<void> {
-		await this.discord.sendMessage(
-			channelId,
+		const message =
 			"This tournament uses player score reporting. At the end of a match, both you and your opponent will have to submit your score.\n" +
-				`If you won 2-0, copy and paste this command:\n\`mc!score ${tournamentId}|2-0\`\n` +
-				`If you won 2-1, copy and paste this command:\n\`mc!score ${tournamentId}|2-1\`\n` +
-				`If you lose 0-2, copy and paste this command:\n\`mc!score ${tournamentId}|0-2\`\n` +
-				`If you lose 1-2, copy and paste this command:\n\`mc!score ${tournamentId}|0-2\`\n` +
-				"If your scores don't match, both of you will need to try again. If you can't agree on what the score was, ask a host to intervene. You will need to send them replays of the games.\n" +
-				`If you want to drop from the tournament and stop playing, copy and paste this command:\n\`mc!drop ${tournamentId}\`\n` +
-				"Please be careful, as using this command will __drop you from the tournament permanently__!"
-		);
+			`If you won 2-0, copy and paste this command:\n\`mc!score ${tournamentId}|2-0\`\n` +
+			`If you won 2-1, copy and paste this command:\n\`mc!score ${tournamentId}|2-1\`\n` +
+			`If you lose 0-2, copy and paste this command:\n\`mc!score ${tournamentId}|0-2\`\n` +
+			`If you lose 1-2, copy and paste this command:\n\`mc!score ${tournamentId}|0-2\`\n` +
+			"If your scores don't match, both of you will need to try again. If you can't agree on what the score was, ask a host to intervene. You will need to send them replays of the games.\n" +
+			`If you want to drop from the tournament and stop playing, copy and paste this command:\n\`mc!drop ${tournamentId}\`\n` +
+			"Please be careful, as using this command will __drop you from the tournament permanently__!";
+		await this.discord.sendMessage(channelId, message);
 	}
+
+	private async sendHostGuide(channelId: string, tournamentId: string): Promise<void> {}
 
 	public async startTournament(tournamentId: string): Promise<void> {
 		const tournament = await this.database.getTournament(tournamentId);

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -366,6 +366,22 @@ export class TournamentManager implements TournamentInterface {
 		await this.database.cleanRegistration(msg.channelId, msg.id);
 	}
 
+	private async sendHostGuideOpen(channelId: string, tournamentId: string): Promise<void> {
+		const message =
+			"Now that you've started your tournaments, players can start signing up.\n" +
+			"If you need to remove a player from the tournament, because they're unwilling or unable to drop themself, you can mention them. So for the player Sample, you'd use this command.\n" +
+			`\`mc!forcedrop ${tournamentId}|@Sample\`\n` +
+			"You can give players round 1 byes, so that they don't duel anyone and automatically get one win in the first round. For this, you mention them. So for the player Sample, you'd use this command.\n" +
+			`\`mc!addbye ${tournamentId}|@Sample\`\n` +
+			`If you made a mistake and need to remove that bye, you can use this command.\n\`mc!removebye ${tournamentId}|@Sample\`\n` +
+			`If you need to see a player's deck, you can mention them. So for the player Sample, you'd use this command.\n\`mc!deck ${tournamentId}|@Sample\`` +
+			"There are three commands that give a breakdown of the players and decks in the tournament, all in CSV format. `players` lists each player and the archetype of their deck, `pie` lists the number of times each archetype has been played, and `dump` lists each player and their decklist.\n" +
+			`These commands are \`mc!players ${tournamentId}\`, \`mc!pie ${tournamentId}\` and \`mc!dump ${tournamentId}\`\n` +
+			"Once all the players you want are signed up, and you're ready to start playing, you can use this command, and after that we'll send more details to private channels on how to proceed.\n" +
+			`\`mc!start ${tournamentId}\``;
+		await this.discord.sendMessage(channelId, message);
+	}
+
 	private CHECK_EMOJI = "✅";
 	public async openTournament(tournamentId: string): Promise<void> {
 		const tournament = await this.database.getTournament(tournamentId);
@@ -388,6 +404,7 @@ export class TournamentManager implements TournamentInterface {
 				await this.database.openRegistration(tournamentId, msg.channelId, msg.id);
 			})
 		);
+		await Promise.all(tournament.privateChannels.map(async c => await this.sendHostGuideOpen(c, tournamentId)));
 	}
 
 	private async sendNewRoundMessage(

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -461,7 +461,16 @@ export class TournamentManager implements TournamentInterface {
 		await this.discord.sendMessage(channelId, message);
 	}
 
-	private async sendHostGuide(channelId: string, tournamentId: string): Promise<void> {}
+	private async sendHostGuideStart(channelId: string, tournamentId: string): Promise<void> {
+		const message =
+			"Now that the first round of the tournament has begun, players are responsible for reporting their own scores." +
+			"However, if they can't, because they have trouble with the command or don't agree on who won, you can step in by mentioning the winner. If the player Sample won with a score of 2-1, use this command.\n" +
+			`\`mc!forcescore ${tournamentId}|2-1|@Sample\`\n` +
+			`Once you've got all the scores for the round and Challonge has generated the next pairings, you can start the timer for the next round at your leisure with this command.\n\`mc!round ${tournamentId}\`\n` +
+			`When all the rounds are complete and the tournament is finished, you can end it with this command.\n\`mc!finish ${tournamentId}\`` +
+			`If you need to stop the tournament early, and you can't finish it properly because you don't have all the scores, you can cancel it with this command. Be careful, because this will __end the tournament permanently__.\n\`mc!cancel ${tournamentId}\``;
+		await this.discord.sendMessage(channelId, message);
+	}
 
 	public async startTournament(tournamentId: string): Promise<void> {
 		const tournament = await this.database.getTournament(tournamentId);
@@ -493,6 +502,8 @@ export class TournamentManager implements TournamentInterface {
 				await this.sendPlayerGuide(c, tournamentId);
 			})
 		);
+		// send command guide to hosts
+		await Promise.all(tournament.privateChannels.map(async c => await this.sendHostGuideStart(c, tournamentId)));
 		// start tournament on challonge
 		await this.website.assignByes(tournamentId, tournament.players.length, tournament.byes);
 		await this.website.startTournament(tournamentId);

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -22,7 +22,12 @@ const command: CommandDefinition = {
 			})
 		);
 		try {
-			const [id, url] = await support.tournamentManager.createTournament(msg.author, msg.serverId, name, desc);
+			const [id, url, guide] = await support.tournamentManager.createTournament(
+				msg.author,
+				msg.serverId,
+				name,
+				desc
+			);
 			// TODO: missing failure path
 			logger.verbose(
 				JSON.stringify({
@@ -38,6 +43,7 @@ const command: CommandDefinition = {
 			await msg.reply(
 				`Tournament ${name} created! You can find it at ${url}. For future commands, refer to this tournament by the id \`${id}\`.`
 			);
+			await msg.reply(guide);
 		} catch (e) {
 			if (e instanceof ChallongeIDConflictError) {
 				await msg.reply(

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,5 +24,6 @@ import { WebsiteInterface } from "./website/interface";
 
 	const tournamentManager = new TournamentManager(discord, database, website);
 	await tournamentManager.loadTimers();
+	await tournamentManager.loadGuides();
 	initializeBehaviours(prefix, discord, tournamentManager);
 })();

--- a/test/commandHandler.ts
+++ b/test/commandHandler.ts
@@ -37,9 +37,8 @@ describe("Tournament creation commands", function () {
 	it("Create tournament", async function () {
 		await discord.simMessage("mc!create name|desc", "create");
 		const response = discord.getResponse("create");
-		expect(response).to.equal(
-			"Tournament name created! You can find it at https://example.com/name. For future commands, refer to this tournament by the id `name`."
-		);
+		// guide message sent after creation response
+		expect(response).to.equal("Guide: mc!help name");
 	});
 	it("Update tournament", async function () {
 		await discord.simMessage("mc!update name|newName|newDesc", "update");

--- a/test/commands/create.unit.ts
+++ b/test/commands/create.unit.ts
@@ -37,7 +37,8 @@ describe("command:create", function () {
 			const authStub = this.stub(support.discord, "authenticateTO").rejects();
 			const createStub = this.stub(support.tournamentManager, "createTournament").resolves([
 				"battlecity",
-				"https://example.com/battlecity"
+				"https://example.com/battlecity",
+				"Guide: mc!help battlecity"
 			]);
 			const replyStub = this.stub(msg, "reply").resolves();
 			expect(command.executor(msg, args, support)).to.be.rejected;
@@ -52,15 +53,18 @@ describe("command:create", function () {
 			const authStub = this.stub(support.discord, "authenticateTO").resolves();
 			const createStub = this.stub(support.tournamentManager, "createTournament").resolves([
 				"battlecity",
-				"https://example.com/battlecity"
+				"https://example.com/battlecity",
+				"Guide: mc!help battlecity"
 			]);
 			const replyStub = this.stub(msg, "reply").resolves();
 			await command.executor(msg, args, support);
 			expect(authStub).to.have.been.called;
 			expect(createStub).to.have.been.calledOnce;
-			expect(replyStub).to.have.been.calledOnceWithExactly(
+			expect(replyStub).to.have.been.calledTwice;
+			expect(replyStub).to.have.been.calledWithExactly(
 				"Tournament battlecity created! You can find it at https://example.com/battlecity. For future commands, refer to this tournament by the id `battlecity`."
 			);
+			expect(replyStub).to.have.been.calledWithExactly("Guide: mc!help battlecity");
 		})
 	);
 	it(
@@ -105,7 +109,8 @@ describe("command:create", function () {
 			const authStub = this.stub(support.discord, "authenticateTO").resolves();
 			const createStub = this.stub(support.tournamentManager, "createTournament").resolves([
 				"battlecity",
-				"https://example.com/battlecity"
+				"https://example.com/battlecity",
+				"Guide: mc!help battlecity"
 			]);
 			const replyStub = this.stub(msg, "reply").rejects();
 			try {

--- a/test/mocks/tournament.ts
+++ b/test/mocks/tournament.ts
@@ -16,10 +16,10 @@ export class TournamentMock implements TournamentInterface {
 		return "This sure is a list.";
 	}
 
-	public async createTournament(hostId: string, serverId: string, name: string): Promise<[string, string]> {
+	public async createTournament(hostId: string, serverId: string, name: string): Promise<[string, string, string]> {
 		// the point of this file is to return a simulated input for testing other files
 		// actual functionality here will be tested with other files
-		return [`${name}`, `https://example.com/${name}`];
+		return [`${name}`, `https://example.com/${name}`, `Guide: mc!help ${name}`];
 	}
 
 	public async registerPlayer(): Promise<void> {

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -99,6 +99,20 @@ describe("Tournament flow commands", function () {
 		expect(discord.getResponse("channel1")).to.equal(
 			"__Registration now open for **Tournament 1**!__\nThe first tournament\n__Click the ✅ below to sign up!__"
 		);
+		const tournamentId = "tourn1";
+		expect(discord.getResponse("channel2")).to.equal(
+			"Now that you've started your tournaments, players can start signing up.\n" +
+				"If you need to remove a player from the tournament, because they're unwilling or unable to drop themself, you can mention them. So for the player Sample, you'd use this command.\n" +
+				`\`mc!forcedrop ${tournamentId}|@Sample\`\n` +
+				"You can give players round 1 byes, so that they don't duel anyone and automatically get one win in the first round. For this, you mention them. So for the player Sample, you'd use this command.\n" +
+				`\`mc!addbye ${tournamentId}|@Sample\`\n` +
+				`If you made a mistake and need to remove that bye, you can use this command.\n\`mc!removebye ${tournamentId}|@Sample\`\n` +
+				`If you need to see a player's deck, you can mention them. So for the player Sample, you'd use this command.\n\`mc!deck ${tournamentId}|@Sample\`` +
+				"There are three commands that give a breakdown of the players and decks in the tournament, all in CSV format. `players` lists each player and the archetype of their deck, `pie` lists the number of times each archetype has been played, and `dump` lists each player and their decklist.\n" +
+				`These commands are \`mc!players ${tournamentId}\`, \`mc!pie ${tournamentId}\` and \`mc!dump ${tournamentId}\`\n` +
+				"Once all the players you want are signed up, and you're ready to start playing, you can use this command, and after that we'll send more details to private channels on how to proceed.\n" +
+				`\`mc!start ${tournamentId}\``
+		);
 		expect(discord.getEmoji("channel1")).to.equal("✅");
 	});
 	it("Open tournament - no channels", async function () {

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -56,9 +56,21 @@ async function noop(): Promise<void> {
 
 describe("Tournament creation commands", async function () {
 	it("Create tournament", async function () {
-		const [id, url] = await tournament.createTournament("testUser", "testServer", "create", "desc");
+		const [id, url, guide] = await tournament.createTournament("testUser", "testServer", "create", "desc");
 		expect(id).to.equal("create");
 		expect(url).to.equal("https://example.com/create");
+		expect(guide).to.equal(
+			"Thanks for hosting your tournament with Emcee! To get started, you'll want to add some announcement channels.\n" +
+				`A public announcement channel will be where players in your tournament will see signups and new rounds. To add the current channel as a public channel, use this command.\n\`mc!addchannel ${id}\`\n` +
+				`To add a different channel as a public announcement channel, mention it. So for a channel called #pairings, use this command.\n\`mc!addchannel ${id}|public|#pairings\`\n` +
+				`A private announcement channel will be where hosts can see the decks players submit. To add the current channel as a private channel, use this command.\n\`mc!addchannel ${id}|private\`\n` +
+				`You can also mention private channels. For a channel called #decks, use this command.\n\`mc!addchannel ${id}|private|#decks\`\n` +
+				`If you want to change the name or description of the tournament, you can use this command.\n\`mc!update ${id}|New Name|A new description\`\n` +
+				`To add another user as a host so they can manage the tournament, you'll mention them. Be careful, only give this privilege to people you'd trust as moderators. For the user Sample, you'd use this command\n` +
+				`\`mc!addhost ${id}|@Sample\`\n` +
+				`If you need to take those privileges away, you can use this command.\n\`mc!removehost ${id}|@Sample\`\n` +
+				`When you're ready to open signups for your tournament, you can use this command, and after that we'll send details to private channels on how to proceed.\n\`mc!open ${id}\``
+		);
 	});
 	it("Create tournament - taken URL", async function () {
 		const [id] = await tournament.createTournament("testUser", "testServer", "create1", "desc");


### PR DESCRIPTION
## Description

Adds guides on how to use commands for tournament hosts, specialised to include the tournaments ID. The guides are not as comprehensive as the player guide, as we assume hosts know roughly what they're doing, or at least can ask us. Guides are separated into several sections for relevance and character limits.
- [x] `create`-`open`
- [x] `open`-`start`
- [x] `start`-`finish`
- [x] More new lines, block text, or some other way to improve the presentation of the guide messages.
- [x] Load guide text from template files.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
