### PR TITLE
Handle failure to send matchup DM

### DIFF
--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -436,7 +436,7 @@ export class TournamentManager implements TournamentInterface {
 					tournament.name
 				}. If they're not a human player, this is normal, but otherwise please tell them their opponent is ${this.discord.mentionUser(
 					opponent
-				)} (${this.discord.getUsername(opponent)})`
+				)} (${this.discord.getUsername(opponent)}), and vice versa.`
 			);
 		}
 	}
@@ -477,7 +477,7 @@ export class TournamentManager implements TournamentInterface {
 					} else {
 						const message = `A new round of ${tournament.name} has begun! ${
 							isBye2
-								? "You have a bye for this round."
+								? "I couldn't find your opponent. If you don't think you should have a bye for this round, please check the pairings."
 								: `Your opponent is ${this.discord.mentionUser(player2)} (${name2}).`
 						}`;
 						await this.discord.sendDirectMessage(player1, message);
@@ -487,7 +487,7 @@ export class TournamentManager implements TournamentInterface {
 					} else {
 						const message = `A new round of ${tournament.name} has begun! ${
 							isBye1
-								? "You have a bye for this round."
+								? "I couldn't find your opponent. If you don't think you should have a bye for this round, please check the pairings."
 								: `Your opponent is ${this.discord.mentionUser(player1)} (${name1}).`
 						}`;
 						await this.discord.sendDirectMessage(player2, message);

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -1,4 +1,5 @@
 import * as csv from "@fast-csv/format";
+import * as fs from "fs/promises";
 import { Deck } from "ydeck";
 import { DatabaseInterface, DatabaseTournament } from "./database/interface";
 import { getDeck } from "./deck/deck";
@@ -8,7 +9,6 @@ import { PersistentTimer } from "./timer";
 import { BlockedDMsError, ChallongeAPIError, TournamentNotFoundError, UserError } from "./util/errors";
 import { getLogger } from "./util/logger";
 import { WebsiteInterface } from "./website/interface";
-import * as fs from "fs/promises";
 
 const logger = getLogger("tournament");
 
@@ -468,8 +468,14 @@ export class TournamentManager implements TournamentInterface {
 				const player1 = players.find(p => p.challongeId === match.player1)?.discordId;
 				const player2 = players.find(p => p.challongeId === match.player2)?.discordId;
 				if (player1 && player2) {
-					const name1 = this.discord.getUsername(player1);
-					const name2 = this.discord.getUsername(player2);
+					let name1 = this.discord.getUsername(player1);
+					if (name1 === player1) {
+						name1 = await this.discord.getRESTUsername(player1);
+					}
+					let name2 = this.discord.getUsername(player2);
+					if (name2 === player2) {
+						name2 = await this.discord.getRESTUsername(player2);
+					}
 					const isBye1 = player1 === name1; // if not bye, ID will be valid and resolve to a name
 					const isBye2 = player2 === name2;
 					if (isBye1) {

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -424,6 +424,23 @@ export class TournamentManager implements TournamentInterface {
 		this.timers[tournament.id] = [];
 	}
 
+	private async reportMatchDMFailure(
+		tournament: DatabaseTournament,
+		userId: string,
+		opponent: string
+	): Promise<void> {
+		for (const channel of tournament.privateChannels) {
+			await this.discord.sendMessage(
+				channel,
+				`I couldn't send a DM to ${this.discord.mentionUser(userId)} (${userId}) about their matchup for ${
+					tournament.name
+				}. If they're not a human player, this is normal, but otherwise please tell them their opponent is ${this.discord.mentionUser(
+					opponent
+				)} (${this.discord.getUsername(opponent)})`
+			);
+		}
+	}
+
 	private async startNewRound(tournament: DatabaseTournament, url: string, skip = false): Promise<void> {
 		const participantRole = this.discord.mentionRole(await this.discord.getPlayerRole(tournament));
 		await this.cancelTimers(tournament);
@@ -451,23 +468,27 @@ export class TournamentManager implements TournamentInterface {
 				const player1 = players.find(p => p.challongeId === match.player1)?.discordId;
 				const player2 = players.find(p => p.challongeId === match.player2)?.discordId;
 				if (player1 && player2) {
-					const mention1 = this.discord.mentionUser(player1);
-					const mention2 = this.discord.mentionUser(player2);
-					const isBye1 = player1 === mention1; // if not bye, ID will be valid and resolve to a mention
-					const isBye2 = player2 === mention2;
-					if (!isBye1) {
+					const name1 = this.discord.getUsername(player1);
+					const name2 = this.discord.getUsername(player2);
+					const isBye1 = player1 === name1; // if not bye, ID will be valid and resolve to a name
+					const isBye2 = player2 === name2;
+					if (isBye1) {
+						await this.reportMatchDMFailure(tournament, player1, player2);
+					} else {
 						const message = `A new round of ${tournament.name} has begun! ${
 							isBye2
 								? "You have a bye for this round."
-								: `Your opponent is ${mention2} (${this.discord.getUsername(player2)}).`
+								: `Your opponent is ${this.discord.mentionUser(player2)} (${name2}).`
 						}`;
 						await this.discord.sendDirectMessage(player1, message);
 					}
-					if (!isBye2) {
+					if (isBye2) {
+						await this.reportMatchDMFailure(tournament, player2, player1);
+					} else {
 						const message = `A new round of ${tournament.name} has begun! ${
 							isBye1
 								? "You have a bye for this round."
-								: `Your opponent is ${mention1} (${this.discord.getUsername(player1)}).`
+								: `Your opponent is ${this.discord.mentionUser(player1)} (${name1}).`
 						}`;
 						await this.discord.sendDirectMessage(player2, message);
 					}

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -325,7 +325,7 @@ export class DatabaseWrapperPostgres implements DatabaseWrapper {
 		if (!participant.hasBye) {
 			throw new UserError(`Player ${playerId} does not have a bye in Tournament ${tournament}`);
 		}
-		participant.hasBye = true;
+		participant.hasBye = false;
 		await participant.save();
 	}
 }

--- a/src/discord/eris.ts
+++ b/src/discord/eris.ts
@@ -56,7 +56,7 @@ export class DiscordWrapperEris implements DiscordWrapper {
 		this.toRoles = {};
 		this.playerRoles = {};
 		this.bot = new Client(discordToken, {
-			getAllUsers: true
+			restMode: true
 		});
 		this.bot.on("ready", () => logger.info(`Logged in as ${this.bot.user.username} - ${this.bot.user.id}`));
 		this.bot.on("messageCreate", this.handleMessage.bind(this));
@@ -356,13 +356,18 @@ export class DiscordWrapperEris implements DiscordWrapper {
 		return msg.mentions[0].id;
 	}
 
+	public async getRESTUsername(userId: string): Promise<string> {
+		const user = await this.bot.getRESTUser(userId);
+		return user ? `${user.username}#${user.discriminator}` : userId;
+	}
+
 	public getUsername(userId: string): string {
 		const user = this.bot.users.get(userId);
 		return user ? `${user.username}#${user.discriminator}` : userId;
 	}
 
 	public async sendDirectMessage(userId: string, content: DiscordMessageOut): Promise<void> {
-		const user = this.bot.users.get(userId);
+		const user = this.bot.users.get(userId) || (await this.bot.getRESTUser(userId));
 		if (!user) {
 			// user error means error by the bot user, not error related to the discord user
 			throw new UserError(`Cannot find user ${userId} to direct message!`);

--- a/src/discord/eris.ts
+++ b/src/discord/eris.ts
@@ -55,7 +55,9 @@ export class DiscordWrapperEris implements DiscordWrapper {
 		this.wrappedMessages = {};
 		this.toRoles = {};
 		this.playerRoles = {};
-		this.bot = new Client(discordToken);
+		this.bot = new Client(discordToken, {
+			getAllUsers: true
+		});
 		this.bot.on("ready", () => logger.info(`Logged in as ${this.bot.user.username} - ${this.bot.user.id}`));
 		this.bot.on("messageCreate", this.handleMessage.bind(this));
 		this.bot.on("messageReactionAdd", this.handleReaction.bind(this));

--- a/src/discord/interface.ts
+++ b/src/discord/interface.ts
@@ -71,6 +71,7 @@ export interface DiscordWrapper {
 	authenticateTO(msg: DiscordMessageIn): Promise<void>;
 	getMentionedUser(msg: DiscordMessageIn): string;
 	getUsername(userId: string): string;
+	getRESTUsername(userId: string): Promise<string>;
 	getPlayerRole(tournamentId: string, channelId: string): Promise<string>;
 	grantPlayerRole(userId: string, roleId: string): Promise<void>;
 	removePlayerRole(userId: string, roleId: string): Promise<void>;
@@ -165,6 +166,10 @@ export class DiscordInterface {
 
 	public getUsername(userId: string): string {
 		return this.api.getUsername(userId);
+	}
+
+	public async getRESTUsername(userId: string): Promise<string> {
+		return await this.api.getRESTUsername(userId);
 	}
 
 	public async sendDirectMessage(userId: string, content: DiscordMessageOut): Promise<void> {

--- a/test/mocks/discord.ts
+++ b/test/mocks/discord.ts
@@ -178,6 +178,10 @@ export class DiscordWrapperMock implements DiscordWrapper {
 		return result[1];
 	}
 
+	public async getRESTUsername(userId: string): Promise<string> {
+		return this.getUsername(userId);
+	}
+
 	public getUsername(userId: string): string {
 		return userId;
 	}


### PR DESCRIPTION
## Description

This resolves two issues with the matchup DM feature. The first is that it wasn't properly checking for user ID validity, using the trivial `mentionUser` function instead of the API-based `getUsername` function. The second is that even with this test fixed, it assumed any failure of the test is a dummy user when in some circumstances a human user can be uncached in Eris. To resolve this, the function now handles a failure to find a user differently, reporting it to the hosts to be manually resolved instead of silently ignoring it. This should be a somewhat rare occurrence, so the implementation being clunky is not the end of the world.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
