### PR TITLE
Fix algorithm for assigning byes to players

### DIFF
--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -560,7 +560,7 @@ export class TournamentManager implements TournamentInterface {
 		// send command guide to hosts
 		await Promise.all(tournament.privateChannels.map(async c => await this.sendHostGuideStart(c, tournamentId)));
 		// start tournament on challonge
-		await this.website.assignByes(tournamentId, tournament.players.length, tournament.byes);
+		await this.website.assignByes(tournamentId, tournament.byes);
 		await this.website.startTournament(tournamentId);
 		const webTourn = await this.website.getTournament(tournamentId);
 		await this.startNewRound(tournament, webTourn.url);

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -125,21 +125,29 @@ export class WebsiteInterface {
 		await this.api.setSeed(tournamentId, playerId, seed);
 	}
 
-	public async assignByes(tournamentId: string, numPlayers: number, playersToBye: string[]): Promise<void> {
+	public async assignByes(tournamentId: string, playersToBye: string[]): Promise<void> {
 		if (playersToBye.length < 1) {
 			return;
 		}
-
-		// Add bye dummy players and rearrange seeds
-		const numByes = playersToBye.length - (numPlayers % 2); // if odd no. of players, 1 can get the natural bye
+		const players = await this.api.getPlayers(tournamentId);
+		const numPlayers = players.length;
+		const numToBye = playersToBye.length;
+		/* With 1 bye left to distribute, if the current number of players is even, we need to add another player
+		   This will have the consequence later of a floating natural bye we want to assign to a player not involved with byes
+		   If the current number of players is odd, we have the natural bye to use and can assign it to a player with a bye
+		   So in that case, we don't want to add that last player.
+		   The current number of players with 1 bye left is N + B - 1, which has opposite parity to N + B.
+		   Hence if N + B is even, we don't have to add the last player, and if it's odd, we need to handle the natural bye later. */
+		const isSumEven = (numPlayers + numToBye) % 2 === 0;
+		const numByes = numToBye - (isSumEven ? 1 : 0);
 		const byePlayers = [];
 		for (let i = 0; i < numByes; i++) {
 			byePlayers.push(await this.registerPlayer(tournamentId, `Round 1 Bye #${i + 1}`, `BYE${i}`));
 		}
-		const maxSeed = numPlayers + numByes; // new no. of players
-		const players = await this.api.getPlayers(tournamentId);
-		// assign natural bye
-		if (numPlayers % 2 === 1) {
+
+		const maxSeed = numPlayers + numByes; // This value is always odd due to the N + B maths above.
+		// Here we assign the natural bye to an appropriate player if we can.
+		if (isSumEven) {
 			// we've checked the length is >0 so pop can't return undefiend
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			const lastPlayerDiscord = playersToBye.pop()!; // modifying this array won't have long-term consequences on the database
@@ -155,9 +163,11 @@ export class WebsiteInterface {
 		// ensure all human players are in top half of the list, which after will remain constant
 		const topSeeds = [];
 		for (let i = 0; i < playersToBye.length; i++) {
-			// assign to low end of top half to minimise unfair boost to tiebreakers,
-			// but assign from top to bottom to ensure they don't push each other into bottom half
-			const newSeed = Math.floor(maxSeed / 2) - playersToBye.length + i;
+			/* We assign to the low end of the top half to minimise an unfair boost to tiebreakers,
+			   but assign from top to bottom to ensure they don't push each other into the bottom half.
+			   We floor because we always want the algorithm to ignore the odd max seed.
+			   If N + B is odd we've put something there, and if N + B is even we want something to be left there. */
+			const newSeed = Math.floor(maxSeed / 2) - playersToBye.length + i + 1;
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			const player = players.find(p => p.discordId === playersToBye[i])!;
 			let seed = player.seed;
@@ -169,11 +179,13 @@ export class WebsiteInterface {
 			topSeeds.push(seed);
 		}
 
-		// should be same as number of byePlayers
+		// should be same as number of byePlayers, given that if N + B even we've knocked one out of that array
 		for (let i = 0; i < topSeeds.length; i++) {
-			// since topSeeds are all in the top half, no modulus needed
-			// set from top to bottom since moving from the bottom
-			// means they won't disturb anything above where they land
+			/* Since the topSeeds are all in the top half, we know adding half the max will stay in bounds.
+			   We set the seeds from top to bottom since we're moving from the bottom,
+			   this means they won't disturb anything above where they land.
+			   Things below where they land are either going to be moved themselves or don't matter.
+			   In particular, if N + B is even we want something to be moved down to the natural bye. */
 			const oppSeed = topSeeds[i] + Math.floor(maxSeed / 2);
 			// we've set discord IDs to this
 			await this.setSeed(tournamentId, byePlayers[i], oppSeed);
@@ -184,8 +196,10 @@ export class WebsiteInterface {
 		const players = await this.api.getPlayers(tournamentId);
 		for (let i = 0; i < numByes; i++) {
 			const player = players.find(p => p.discordId === `BYE${i}`);
-			// could assert non-null here cuz we made these players
-			// but this is simple enough and handles them being manually dropped
+			/* One would think we could assert non-null here because we made these players,
+			   However, if N + B even (see above comments), BYE${numByes} won't exist,
+			   and this is simpler than calculating that again.
+			   This also neatly handles edge cases like a bye player being manually dropped. */
 			if (player) {
 				const match = await this.api.getMatchWithPlayer(tournamentId, player.challongeId);
 				const winner = match.player1 === player.challongeId ? match.player2 : match.player1;

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -125,10 +125,12 @@ export class WebsiteInterface {
 		await this.api.setSeed(tournamentId, playerId, seed);
 	}
 
-	public async assignByes(tournamentId: string, playersToBye: string[]): Promise<void> {
+	public async assignByes(tournamentId: string, inPlayersToBye: string[]): Promise<void> {
+		const playersToBye = inPlayersToBye.slice(0); // shallow copy to sever reference for when we pop
 		if (playersToBye.length < 1) {
 			return;
 		}
+
 		const players = await this.api.getPlayers(tournamentId);
 		const numPlayers = players.length;
 		const numToBye = playersToBye.length;

--- a/test/website.ts
+++ b/test/website.ts
@@ -94,11 +94,11 @@ describe("Misc functions", function () {
 	});
 
 	it("assignByes - no byes", async function () {
-		await expect(website.assignByes("test", 0, [])).to.not.be.rejected;
+		await expect(website.assignByes("test", [])).to.not.be.rejected;
 	});
 
 	it("assignByes - natural bye", async function () {
-		await expect(website.assignByes("bye", 1, ["player1"])).to.not.be.rejected;
+		await expect(website.assignByes("bye", ["player1"])).to.not.be.rejected;
 	});
 
 	it("dropByes - no byes", async function () {


### PR DESCRIPTION
## Description

There was an issue with the algorithm I thought was an edge case where assigning 1 bye to 2 players would try to set a player's seed to 0, which is invalid. Investigating this I realised much of the logic of the algorithm was slightly incorrect, in particular assumptions relating the parity of the number of players to how the natural bye is used. Correcting this also revealed the off-by-one error in the original "edge case", which I imagine would have been much more frequent than I thought and with the other fixes would now be consistent.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] This change has been tested, either in practice or with appropriate unit tests.