### PR TITLE
Fix website#getBye

### DIFF
--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -79,9 +79,14 @@ export class WebsiteInterface {
 			return undefined;
 		}
 		const matches = await this.api.getMatches(tournamentId);
-		const bye = tournament.players.find(
-			p => !matches.find(m => m.player1 === p.challongeId || m.player2 === p.challongeId)
-		);
+		// Find a player for which the following is true
+		const bye = tournament.players.find(p => {
+			// Find a match which includes the player
+			const match = matches.find(m => m.player1 === p.challongeId || m.player2 === p.challongeId);
+			// Negate: if we found a match, this player doesn't have the bye.
+			return !match;
+		});
+		// This finds a player not in any match - i.e., they have the bye
 		return bye?.discordId;
 	}
 

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -80,7 +80,7 @@ export class WebsiteInterface {
 		}
 		const matches = await this.api.getMatches(tournamentId);
 		const bye = tournament.players.find(
-			p => !matches.find(m => m.player1 !== p.challongeId && m.player2 !== p.challongeId)
+			p => !matches.find(m => m.player1 === p.challongeId || m.player2 === p.challongeId)
 		);
 		return bye?.discordId;
 	}


### PR DESCRIPTION
## Description

Too many negations meant it was searching for the first player who wasn't in every match - a criterion true of every player. It now correctly finds the first (and only) player who's not in any match.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
