### PR TITLE
Fix check for challonge URL being taken

### DIFF
--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -158,7 +158,12 @@ export class TournamentManager implements TournamentInterface {
 			await this.website.getTournament(url);
 			return true;
 		} catch (e) {
-			// if the error is it not being found on website
+			// This is an error which means the name is taken,
+			// just not by Emcee.
+			if (e.message === "You only have read access to this tournament") {
+				return true;
+			}
+			// If the error is it not being found on website,
 			// we should continue to the database check
 			if (!(e instanceof ChallongeAPIError)) {
 				throw e;


### PR DESCRIPTION
## Description

It turns out if the URL does exist but was not created by Emcee, trying to get that tournament does produce an error, so we have to check for that error explicitly, not only success.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
