### PR TITLE
Properly handle deck submission without attached deck

### DIFF
--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -291,6 +291,10 @@ export class TournamentManager implements TournamentInterface {
 		if (tournaments.length === 1) {
 			const tournament = tournaments[0];
 			const deck = await getDeckFromMessage(msg);
+			if (!deck) {
+				await msg.reply("Must provide either attached `.ydk` file or valid `ydke://` URL!");
+				return;
+			}
 			const [content, file] = prettyPrint(deck, `${this.discord.getUsername(msg.author)}.ydk`);
 			if (deck.validationErrors.length > 0) {
 				await msg.reply(
@@ -338,6 +342,10 @@ export class TournamentManager implements TournamentInterface {
 		if (confirmedTourns.length === 1) {
 			const tournament = confirmedTourns[0];
 			const deck = await getDeckFromMessage(msg);
+			if (!deck) {
+				await msg.reply("Must provide either attached `.ydk` file or valid `ydke://` URL!");
+				return;
+			}
 			const [content, file] = prettyPrint(deck, `${this.discord.getUsername(msg.author)}.ydk`);
 			if (deck.validationErrors.length > 0) {
 				await msg.reply(

--- a/src/deck/discordDeck.ts
+++ b/src/deck/discordDeck.ts
@@ -2,7 +2,6 @@ import fetch from "node-fetch";
 import { Deck, UrlConstructionError } from "ydeck";
 import { DeckError } from "ydeck/dist/validation";
 import { DiscordAttachmentOut, DiscordMessageIn, DiscordMessageOut, splitText } from "../discord/interface";
-import { DeckNotFoundError } from "../util/errors";
 import { getDeck } from "./deck";
 
 async function extractYdk(msg: DiscordMessageIn): Promise<string> {
@@ -12,7 +11,7 @@ async function extractYdk(msg: DiscordMessageIn): Promise<string> {
 	return ydk;
 }
 
-export async function getDeckFromMessage(msg: DiscordMessageIn): Promise<Deck> {
+export async function getDeckFromMessage(msg: DiscordMessageIn): Promise<Deck | null> {
 	if (msg.attachments.length > 0 && msg.attachments[0].filename.endsWith(".ydk")) {
 		const ydk = await extractYdk(msg);
 		const url = Deck.ydkToUrl(ydk);
@@ -22,7 +21,7 @@ export async function getDeckFromMessage(msg: DiscordMessageIn): Promise<Deck> {
 		return getDeck(msg.content); // This function will parse out a ydke URL if present
 	} catch (e) {
 		if (e instanceof UrlConstructionError) {
-			throw new DeckNotFoundError();
+			return null;
 		} else {
 			throw e;
 		}

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -49,10 +49,6 @@ export class UnauthorisedTOError extends UserError {
 	}
 }
 
-export class DeckNotFoundError extends UserError {
-	message = "Must provide either attached `.ydk` file or valid `ydke://` URL!";
-}
-
 export class AssertTextChannelError extends UserError {
 	channelId: string;
 

--- a/test/deck.ts
+++ b/test/deck.ts
@@ -1,10 +1,7 @@
-import chai, { expect } from "chai";
+import { expect } from "chai";
 import { getDeckFromMessage, prettyPrint } from "../src/deck/discordDeck";
 import { DiscordEmbed, DiscordMessageIn } from "../src/discord/interface";
-import { DeckNotFoundError } from "../src/util/errors";
-import chaiAsPromised from "chai-as-promised";
 import { getDeck } from "../src/deck/deck";
-chai.use(chaiAsPromised);
 
 async function noop(): Promise<void> {
 	return;
@@ -28,7 +25,7 @@ describe("Get deck from message", function () {
 			"ydke://5m3qBeZt6gV9+McCffjHAn34xwK8beUDvG3lA7xt5QMfX5ICWvTJAVr0yQFa9MkBrDOdBKwznQSsM50Ey/UzAMv1MwDL9TMAdAxQBQ6wYAKvI94AryPeAK8j3gCmm/QBWXtjBOMavwDjGr8A4xq/AD6kcQGeE8oEnhPKBJ4TygSlLfUDpS31A6Ut9QMiSJkAIkiZACJImQCANVMDgDVTAw==!FtIXALVcnwC1XJ8AiBF2A4gRdgNLTV4Elt0IAMf4TQHCT0EAvw5JAqSaKwD5UX8EweoDA2LO9ATaI+sD!H1+SAg==!";
 		const deck = await getDeckFromMessage(sampleMessage);
 		sampleMessage.content = "";
-		expect(deck.mainSize).to.equal(40); // more details in ydeck tests, just checking we got something
+		expect(deck?.mainSize).to.equal(40); // more details in ydeck tests, just checking we got something
 	});
 	it("YDK", async function () {
 		sampleMessage.attachments = [
@@ -40,10 +37,11 @@ describe("Get deck from message", function () {
 		];
 		const deck = await getDeckFromMessage(sampleMessage);
 		sampleMessage.attachments = [];
-		expect(deck.mainSize).to.equal(40); // more details in ydeck tests, just checking we got something
+		expect(deck?.mainSize).to.equal(40); // more details in ydeck tests, just checking we got something
 	});
 	it("None", async function () {
-		await expect(getDeckFromMessage(sampleMessage)).to.be.rejectedWith(DeckNotFoundError);
+		const deck = await getDeckFromMessage(sampleMessage);
+		expect(deck).to.be.null;
 	});
 });
 


### PR DESCRIPTION
## Description

The previous implementation threw an error expecting it to be caught by the command handler, but deck submission doesn't occur through a command, so it simply crashes. Now we instead return `null` and check for it.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
