### PR TITLE
Add guards for tournament status when using commands

### DIFF
--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -7,13 +7,7 @@ import { getDeck } from "./deck/deck";
 import { getDeckFromMessage, prettyPrint } from "./deck/discordDeck";
 import { DiscordAttachmentOut, DiscordInterface, DiscordMessageIn, DiscordMessageLimited } from "./discord/interface";
 import { PersistentTimer } from "./timer";
-import {
-	AssertStatusError,
-	BlockedDMsError,
-	ChallongeAPIError,
-	TournamentNotFoundError,
-	UserError
-} from "./util/errors";
+import { BlockedDMsError, ChallongeAPIError, TournamentNotFoundError, UserError } from "./util/errors";
 import { getLogger } from "./util/logger";
 import { WebsiteInterface, WebsiteTournament } from "./website/interface";
 

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -423,8 +423,7 @@ export class TournamentManager implements TournamentInterface {
 
 	private CHECK_EMOJI = "✅";
 	public async openTournament(tournamentId: string): Promise<void> {
-		await this.database.assertStatus(tournamentId, TournamentStatus.PREPARING);
-		const tournament = await this.database.getTournament(tournamentId);
+		const tournament = await this.database.getTournament(tournamentId, TournamentStatus.PREPARING);
 		const channels = tournament.publicChannels;
 		if (channels.length < 1) {
 			throw new UserError(
@@ -576,8 +575,7 @@ export class TournamentManager implements TournamentInterface {
 	}
 
 	public async startTournament(tournamentId: string): Promise<void> {
-		await this.database.assertStatus(tournamentId, TournamentStatus.PREPARING);
-		const tournament = await this.database.getTournament(tournamentId);
+		const tournament = await this.database.getTournament(tournamentId, TournamentStatus.PREPARING);
 		if (tournament.players.length < 2) {
 			throw new UserError("Cannot start a tournament without at least 2 confirmed participants!");
 		}
@@ -618,8 +616,7 @@ export class TournamentManager implements TournamentInterface {
 	}
 
 	public async finishTournament(tournamentId: string, cancel = false): Promise<void> {
-		await this.database.assertStatus(tournamentId, TournamentStatus.IPR);
-		const tournament = await this.database.getTournament(tournamentId);
+		const tournament = await this.database.getTournament(tournamentId, TournamentStatus.IPR);
 		const channels = tournament.publicChannels;
 		let webTourn: WebsiteTournament;
 		if (!cancel) {
@@ -691,8 +688,7 @@ export class TournamentManager implements TournamentInterface {
 		scoreOpp: number,
 		host = false
 	): Promise<string> {
-		await this.database.assertStatus(tournamentId, TournamentStatus.IPR);
-		const tournament = await this.database.getTournament(tournamentId);
+		const tournament = await this.database.getTournament(tournamentId, TournamentStatus.IPR);
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const player = tournament.findPlayer(playerId)!;
 		const match = await this.website.findMatch(tournamentId, player.challongeId);
@@ -757,8 +753,7 @@ export class TournamentManager implements TournamentInterface {
 	// specifically only handles telling participants about a new round
 	// hosts should handle outstanding scores individually with forcescore
 	public async nextRound(tournamentId: string, skip = false): Promise<void> {
-		await this.database.assertStatus(tournamentId, TournamentStatus.IPR);
-		const tournament = await this.database.getTournament(tournamentId);
+		const tournament = await this.database.getTournament(tournamentId, TournamentStatus.IPR);
 		const webTourn = await this.website.getTournament(tournamentId);
 		await this.startNewRound(tournament, webTourn.url, skip);
 	}
@@ -902,14 +897,12 @@ export class TournamentManager implements TournamentInterface {
 	}
 
 	public async registerBye(tournamentId: string, playerId: string): Promise<string[]> {
-		await this.database.assertStatus(tournamentId, TournamentStatus.PREPARING);
 		await this.database.registerBye(tournamentId, playerId);
 		const tournament = await this.database.getTournament(tournamentId);
 		return tournament.byes;
 	}
 
 	public async removeBye(tournamentId: string, playerId: string): Promise<string[]> {
-		await this.database.assertStatus(tournamentId, TournamentStatus.PREPARING);
 		await this.database.removeBye(tournamentId, playerId);
 		const tournament = await this.database.getTournament(tournamentId);
 		return tournament.byes;

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -365,7 +365,9 @@ export class TournamentManager implements TournamentInterface {
 		}
 		// allow confirmed user to resubmit
 		const allTourns = await this.database.listTournaments();
-		const confirmedTourns = allTourns.filter(t => t.players.includes(msg.author) && t.status === "preparing");
+		const confirmedTourns = allTourns.filter(
+			t => t.players.includes(msg.author) && t.status === TournamentStatus.PREPARING
+		);
 		if (confirmedTourns.length > 1) {
 			const out = confirmedTourns.map(t => t.name).join(", ");
 			await msg.reply(
@@ -375,16 +377,7 @@ export class TournamentManager implements TournamentInterface {
 		}
 		if (confirmedTourns.length === 1) {
 			const tournament = confirmedTourns[0];
-			try {
-				await this.database.assertStatus(tournament.id, TournamentStatus.PREPARING);
-			} catch (e) {
-				if (e instanceof AssertStatusError) {
-					await msg.reply(
-						`You're trying to update your deck for ${tournament.name}, but you can't change your decklist for a tournament that has already begun!`
-					);
-				}
-				// TODO: handle other errors? need to be more thorough in non-command functions in general
-			}
+			// tournament already confirmed preparing by filter
 			const deck = await getDeckFromMessage(msg);
 			if (!deck) {
 				await msg.reply("Must provide either attached `.ydk` file or valid `ydke://` URL!");

--- a/src/database/interface.ts
+++ b/src/database/interface.ts
@@ -65,7 +65,6 @@ export interface DatabaseTournament {
 	publicChannels: string[];
 	privateChannels: string[];
 	byes: string[];
-	findHost: (id: string) => boolean;
 	findPlayer: (id: string) => DatabasePlayer | undefined;
 }
 

--- a/src/database/interface.ts
+++ b/src/database/interface.ts
@@ -21,9 +21,12 @@ export interface DatabaseWrapper {
 	getRegisterMessages(tournamentId?: string): Promise<DatabaseMessage[]>;
 	cleanRegistration(channelId: string, messageId: string): Promise<void>;
 	getPendingTournaments(playerId: string): Promise<DatabaseTournament[]>;
-	getTournamentFromMessage(channelId: string, messageId: string): Promise<DatabaseTournament | undefined>;
-	addPendingPlayer(tournamentId: string, playerId: string): Promise<boolean>;
-	removePendingPlayer(tournamentId: string, playerId: string): Promise<boolean>;
+	addPendingPlayer(channelId: string, messageId: string, playerId: string): Promise<DatabaseTournament | undefined>;
+	removePendingPlayer(
+		channelId: string,
+		messageId: string,
+		playerId: string
+	): Promise<DatabaseTournament | undefined>;
 	confirmPlayer(tournamentId: string, playerId: string, challongeId: number, deck: string): Promise<void>;
 	removeConfirmedPlayerReaction(
 		channelId: string,
@@ -158,13 +161,7 @@ export class DatabaseInterface {
 		messageId: string,
 		playerId: string
 	): Promise<DatabaseTournament | undefined> {
-		const tournament = await this.db.getTournamentFromMessage(channelId, messageId);
-		if (!tournament || tournament.status !== TournamentStatus.PREPARING) {
-			return;
-		}
-		if (await this.db.addPendingPlayer(tournament.id, playerId)) {
-			return tournament;
-		}
+		return await this.db.addPendingPlayer(channelId, messageId, playerId);
 	}
 
 	public async removePendingPlayer(
@@ -172,13 +169,7 @@ export class DatabaseInterface {
 		messageId: string,
 		playerId: string
 	): Promise<DatabaseTournament | undefined> {
-		const tournament = await this.db.getTournamentFromMessage(channelId, messageId);
-		if (!tournament || tournament.status !== TournamentStatus.PREPARING) {
-			return;
-		}
-		if (await this.db.removePendingPlayer(tournament.id, playerId)) {
-			return tournament;
-		}
+		return await this.db.removePendingPlayer(channelId, messageId, playerId);
 	}
 
 	public async confirmPlayer(

--- a/src/database/interface.ts
+++ b/src/database/interface.ts
@@ -1,5 +1,6 @@
-import { UnauthorisedHostError, UnauthorisedPlayerError } from "../util/errors";
+import { UnauthorisedHostError, UnauthorisedPlayerError, AssertStatusError } from "../util/errors";
 import { WebsiteTournament } from "../website/interface";
+import { TournamentStatus } from "./orm";
 
 export interface DatabaseWrapper {
 	createTournament(
@@ -56,7 +57,7 @@ export interface DatabaseTournament {
 	id: string;
 	name: string;
 	description: string;
-	status: "preparing" | "in progress" | "complete";
+	status: TournamentStatus;
 	hosts: string[];
 	players: string[]; // list of IDs, for more info use findPlayer();
 	server: string;
@@ -92,6 +93,13 @@ export class DatabaseInterface {
 		const player = tournament.findPlayer(playerId);
 		if (!player) {
 			throw new UnauthorisedPlayerError(playerId, tournamentId);
+		}
+	}
+
+	public async assertStatus(tournamentId: string, requiredStatus: TournamentStatus): Promise<void> {
+		const tournament = await this.getTournament(tournamentId);
+		if (tournament.status !== requiredStatus) {
+			throw new AssertStatusError(tournamentId, requiredStatus, tournament.status);
 		}
 	}
 

--- a/src/database/interface.ts
+++ b/src/database/interface.ts
@@ -1,4 +1,3 @@
-import { UnauthorisedHostError, UnauthorisedPlayerError } from "../util/errors";
 import { WebsiteTournament } from "../website/interface";
 import { TournamentStatus } from "./orm";
 
@@ -11,6 +10,8 @@ export interface DatabaseWrapper {
 		description: string
 	): Promise<DatabaseTournament>;
 	updateTournament(tournamentId: string, name: string, desc: string): Promise<void>;
+	authenticateHost(tournamentId: string, hostId: string): Promise<void>;
+	authenticatePlayer(tournamentId: string, playerId: string): Promise<void>;
 	getTournament(tournamentId: string, assertStatus?: TournamentStatus): Promise<DatabaseTournament>;
 	getActiveTournaments(server?: string): Promise<DatabaseTournament[]>;
 	addAnnouncementChannel(tournamentId: string, channelId: string, type: "public" | "private"): Promise<void>;
@@ -81,19 +82,11 @@ export class DatabaseInterface {
 	}
 
 	public async authenticateHost(tournamentId: string, hostId: string): Promise<void> {
-		const tournament = await this.getTournament(tournamentId);
-		const auth = tournament.findHost(hostId);
-		if (!auth) {
-			throw new UnauthorisedHostError(hostId, tournamentId);
-		}
+		return await this.db.authenticateHost(tournamentId, hostId);
 	}
 
 	public async authenticatePlayer(tournamentId: string, playerId: string): Promise<void> {
-		const tournament = await this.getTournament(tournamentId);
-		const player = tournament.findPlayer(playerId);
-		if (!player) {
-			throw new UnauthorisedPlayerError(playerId, tournamentId);
-		}
+		return await this.db.authenticatePlayer(tournamentId, playerId);
 	}
 
 	public async listTournaments(server?: string): Promise<DatabaseTournament[]> {

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -35,7 +35,6 @@ export class DatabaseWrapperPostgres implements DatabaseWrapper {
 			privateChannels: tournament.privateChannels.slice(),
 			server: tournament.owningDiscordServer,
 			byes: tournament.confirmed.filter(p => p.hasBye).map(p => p.discordId),
-			findHost: (id: string): boolean => tournament.hosts.includes(id),
 			findPlayer: (id: string): DatabasePlayer => {
 				const p = tournament.confirmed.find(p => p.discordId === id);
 				if (!p) {

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -107,7 +107,7 @@ export class DatabaseWrapperPostgres implements DatabaseWrapper {
 	async updateTournament(tournamentId: string, name: string, desc: string): Promise<void> {
 		const tournament = await this.findTournament(tournamentId);
 		if (tournament.status !== TournamentStatus.PREPARING) {
-			throw new UserError(`It's too late to update the information for ${tournament.name}.`);
+			throw new AssertStatusError(tournamentId, TournamentStatus.PREPARING, tournament.status);
 		}
 		tournament.name = name;
 		tournament.description = desc;

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -71,7 +71,7 @@ export class AssertStatusError extends UserError {
 	requiredStatus: TournamentStatus;
 	currentStatus: TournamentStatus;
 	constructor(tournamentId: string, requiredStatus: TournamentStatus, currentStatus: TournamentStatus) {
-		super(`Tournament ${tournamentId} must be in be ${requiredStatus}, but is currently ${currentStatus}.`);
+		super(`Tournament ${tournamentId} must be ${requiredStatus}, but is currently ${currentStatus}.`);
 		this.tournamentId = tournamentId;
 		this.requiredStatus = requiredStatus;
 		this.currentStatus = currentStatus;

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -1,3 +1,5 @@
+import { TournamentStatus } from "../database/orm";
+
 export class UserError extends Error {}
 
 export class ChallongeAPIError extends Error {}
@@ -61,6 +63,18 @@ export class AssertTextChannelError extends UserError {
 export class BlockedDMsError extends UserError {
 	constructor(userId: string) {
 		super(`User <@${userId}> does not accept DMs from me! Please ask them to change their settings to allow this.`);
+	}
+}
+
+export class AssertStatusError extends UserError {
+	tournamentId: string;
+	requiredStatus: TournamentStatus;
+	currentStatus: TournamentStatus;
+	constructor(tournamentId: string, requiredStatus: TournamentStatus, currentStatus: TournamentStatus) {
+		super(`Tournament ${tournamentId} must be in be ${requiredStatus}, but is currently ${currentStatus}.`);
+		this.tournamentId = tournamentId;
+		this.requiredStatus = requiredStatus;
+		this.currentStatus = currentStatus;
 	}
 }
 

--- a/test/discord.ts
+++ b/test/discord.ts
@@ -1,6 +1,7 @@
 import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { DatabaseTournament } from "../src/database/interface";
+import { TournamentStatus } from "../src/database/orm";
 import { DiscordInterface, DiscordMessageHandler, DiscordMessageIn, splitText } from "../src/discord/interface";
 import { DiscordWrapperMock } from "./mocks/discord";
 chai.use(chaiAsPromised);
@@ -116,7 +117,7 @@ const sampleTournament: DatabaseTournament = {
 	id: "test",
 	name: "Test tournament",
 	description: "A sample tournament",
-	status: "preparing",
+	status: TournamentStatus.PREPARING,
 	hosts: ["testHost"],
 	players: [],
 	server: "testServer",

--- a/test/discord.ts
+++ b/test/discord.ts
@@ -124,7 +124,6 @@ const sampleTournament: DatabaseTournament = {
 	publicChannels: [],
 	privateChannels: [],
 	byes: [],
-	findHost: () => true,
 	findPlayer: () => {
 		return { discordId: "testPlayer", challongeId: 1, deck: "" };
 	}

--- a/test/mocks/database.ts
+++ b/test/mocks/database.ts
@@ -17,9 +17,6 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				privateChannels: ["channel2"],
 				server: "testServer",
 				byes: ["player1"],
-				findHost(id: string): boolean {
-					return !id.startsWith("not");
-				},
 				findPlayer(id: string): DatabasePlayer | undefined {
 					if (id.startsWith("not")) {
 						return;
@@ -43,9 +40,6 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				hosts: ["host2"],
 				server: "testServer",
 				byes: ["player2"],
-				findHost(): boolean {
-					return true;
-				},
 				findPlayer(id: string): DatabasePlayer {
 					return {
 						discordId: id,
@@ -66,9 +60,6 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				privateChannels: ["channel2"],
 				server: "testServer",
 				byes: [],
-				findHost(id: string): boolean {
-					return !id.startsWith("not");
-				},
 				findPlayer(id: string): DatabasePlayer | undefined {
 					if (id.startsWith("not")) {
 						return;
@@ -112,9 +103,6 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 			hosts: [hostId],
 			server: serverId,
 			byes: [],
-			findHost(): boolean {
-				return true;
-			},
 			findPlayer(id: string): DatabasePlayer {
 				return {
 					discordId: id,
@@ -143,7 +131,6 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				publicChannels: [],
 				privateChannels: [],
 				byes: [],
-				findHost: (): boolean => true,
 				findPlayer: (): undefined => undefined
 			};
 		}
@@ -159,7 +146,6 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				publicChannels: [],
 				privateChannels: [],
 				byes: [],
-				findHost: (): boolean => true,
 				findPlayer: (): undefined => undefined
 			};
 		}
@@ -175,7 +161,6 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				publicChannels: [],
 				privateChannels: [],
 				byes: [],
-				findHost: (): boolean => true,
 				findPlayer: (): undefined => undefined
 			};
 		}
@@ -191,7 +176,6 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				publicChannels: ["channel1"],
 				privateChannels: ["channel2"],
 				byes: [],
-				findHost: (): boolean => true,
 				findPlayer: (): undefined => undefined
 			};
 		}
@@ -207,7 +191,6 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				publicChannels: ["topChannel"],
 				privateChannels: ["channel2"],
 				byes: [],
-				findHost: (): boolean => true,
 				findPlayer: (p: string): DatabasePlayer => {
 					return {
 						discordId: p,

--- a/test/mocks/database.ts
+++ b/test/mocks/database.ts
@@ -1,6 +1,6 @@
 import { DatabaseMessage, DatabasePlayer, DatabaseTournament, DatabaseWrapper } from "../../src/database/interface";
 import { TournamentStatus } from "../../src/database/orm";
-import { TournamentNotFoundError } from "../../src/util/errors";
+import { TournamentNotFoundError, UnauthorisedHostError, UnauthorisedPlayerError } from "../../src/util/errors";
 
 export class DatabaseWrapperMock implements DatabaseWrapper {
 	tournaments: DatabaseTournament[];
@@ -82,6 +82,16 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				}
 			}
 		];
+	}
+	async authenticateHost(tournamentId: string, userId: string): Promise<void> {
+		if (userId.startsWith("not")) {
+			throw new UnauthorisedHostError(userId, tournamentId);
+		}
+	}
+	async authenticatePlayer(tournamentId: string, userId: string): Promise<void> {
+		if (userId.startsWith("not")) {
+			throw new UnauthorisedPlayerError(userId, tournamentId);
+		}
 	}
 	async createTournament(
 		hostId: string,

--- a/test/mocks/database.ts
+++ b/test/mocks/database.ts
@@ -49,7 +49,33 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				findPlayer(id: string): DatabasePlayer {
 					return {
 						discordId: id,
-						challongeId: parseInt(id, 10), // will turn player1 into 1
+						challongeId: parseInt(id.slice(id.length - 1), 10), // will turn player1 into 1
+						deck:
+							"ydke://5m3qBeZt6gV9+McCffjHAn34xwK8beUDvG3lA7xt5QMfX5ICWvTJAVr0yQFa9MkBrDOdBKwznQSsM50Ey/UzAMv1MwDL9TMAdAxQBQ6wYAKvI94AryPeAK8j3gCmm/QBWXtjBOMavwDjGr8A4xq/AD6kcQGeE8oEnhPKBJ4TygSlLfUDpS31A6Ut9QMiSJkAIkiZACJImQCANVMDgDVTAw==!FtIXALVcnwC1XJ8AiBF2A4gRdgNLTV4Elt0IAMf4TQHCT0EAvw5JAqSaKwD5UX8EweoDA2LO9ATaI+sD!H1+SAg==!"
+					};
+				}
+			},
+			{
+				id: "tourn3",
+				name: "Tournament 3",
+				description: "The third tournament",
+				status: TournamentStatus.PREPARING,
+				hosts: ["host1"],
+				players: ["sTooMany"],
+				publicChannels: ["channel1"],
+				privateChannels: ["channel2"],
+				server: "testServer",
+				byes: [],
+				findHost(id: string): boolean {
+					return !id.startsWith("not");
+				},
+				findPlayer(id: string): DatabasePlayer | undefined {
+					if (id.startsWith("not")) {
+						return;
+					}
+					return {
+						discordId: id,
+						challongeId: parseInt(id.slice(id.length - 1), 10), // will turn player1 into 1
 						deck:
 							"ydke://5m3qBeZt6gV9+McCffjHAn34xwK8beUDvG3lA7xt5QMfX5ICWvTJAVr0yQFa9MkBrDOdBKwznQSsM50Ey/UzAMv1MwDL9TMAdAxQBQ6wYAKvI94AryPeAK8j3gCmm/QBWXtjBOMavwDjGr8A4xq/AD6kcQGeE8oEnhPKBJ4TygSlLfUDpS31A6Ut9QMiSJkAIkiZACJImQCANVMDgDVTAw==!FtIXALVcnwC1XJ8AiBF2A4gRdgNLTV4Elt0IAMf4TQHCT0EAvw5JAqSaKwD5UX8EweoDA2LO9ATaI+sD!H1+SAg==!"
 					};
@@ -221,13 +247,13 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 		}
 		return [this.tournaments[0]];
 	}
-	async getTournamentFromMessage(): Promise<DatabaseTournament> {
+	async getTournamentFromMessage(channelId: string, messageId: string): Promise<DatabaseTournament | undefined> {
+		if (channelId.startsWith("wrong") || messageId.startsWith("wrong")) {
+			return;
+		}
 		return this.tournaments[0];
 	}
-	async addPendingPlayer(tournamentId: string): Promise<boolean> {
-		if (tournamentId.startsWith("wrong") || tournamentId.startsWith("wrong")) {
-			return false;
-		}
+	async addPendingPlayer(): Promise<boolean> {
 		return true;
 	}
 	async removePendingPlayer(): Promise<boolean> {

--- a/test/mocks/database.ts
+++ b/test/mocks/database.ts
@@ -247,17 +247,14 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 		}
 		return [this.tournaments[0]];
 	}
-	async getTournamentFromMessage(channelId: string, messageId: string): Promise<DatabaseTournament | undefined> {
+	async addPendingPlayer(channelId: string, messageId: string): Promise<DatabaseTournament | undefined> {
 		if (channelId.startsWith("wrong") || messageId.startsWith("wrong")) {
 			return;
 		}
 		return this.tournaments[0];
 	}
-	async addPendingPlayer(): Promise<boolean> {
-		return true;
-	}
-	async removePendingPlayer(): Promise<boolean> {
-		return true;
+	async removePendingPlayer(): Promise<DatabaseTournament | undefined> {
+		return this.tournaments[0];
 	}
 	async confirmPlayer(tournamentId: string, playerId: string): Promise<void> {
 		const index = this.tournaments.findIndex(t => t.id === tournamentId);

--- a/test/mocks/database.ts
+++ b/test/mocks/database.ts
@@ -1,4 +1,5 @@
 import { DatabaseMessage, DatabasePlayer, DatabaseTournament, DatabaseWrapper } from "../../src/database/interface";
+import { TournamentStatus } from "../../src/database/orm";
 import { TournamentNotFoundError } from "../../src/util/errors";
 
 export class DatabaseWrapperMock implements DatabaseWrapper {
@@ -9,7 +10,7 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				id: "tourn1",
 				name: "Tournament 1",
 				description: "The first tournament",
-				status: "preparing",
+				status: TournamentStatus.PREPARING,
 				hosts: ["host1"],
 				players: ["player1", "player2", "sJustRight", "sTooMany"],
 				publicChannels: ["channel1"],
@@ -35,7 +36,7 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				id: "tourn2",
 				name: "Tournament 2",
 				description: "The second tournament",
-				status: "preparing",
+				status: TournamentStatus.IPR,
 				players: ["player1", "player2", "sTooMany"],
 				publicChannels: ["channel1"],
 				privateChannels: ["channel2"],
@@ -63,7 +64,7 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 		name: string,
 		description: string
 	): Promise<DatabaseTournament> {
-		const status = "preparing" as const;
+		const status = TournamentStatus.PREPARING;
 		const newTournament = {
 			id: tournamentId,
 			name: name,
@@ -99,7 +100,7 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				id: tournamentId,
 				name: "Small tournament",
 				description: "A Small Tournament",
-				status: "preparing",
+				status: TournamentStatus.PREPARING,
 				hosts: ["testHost"],
 				players: [],
 				server: "testServer",
@@ -115,7 +116,7 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				id: tournamentId,
 				name: "Small tournament",
 				description: "A Small Tournament",
-				status: "preparing",
+				status: TournamentStatus.PREPARING,
 				hosts: ["testHost"],
 				players: [],
 				server: "testServer",
@@ -131,7 +132,7 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				id: tournamentId,
 				name: "Bye tournament",
 				description: "A tournament with a natural bye",
-				status: "preparing",
+				status: TournamentStatus.PREPARING,
 				hosts: ["testHost"],
 				players: ["a", "b", "c"],
 				server: "testServer",
@@ -147,7 +148,7 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				id: tournamentId,
 				name: "Pending tournament",
 				description: "A tournament with a pending player",
-				status: "preparing",
+				status: TournamentStatus.PREPARING,
 				hosts: ["testHost"],
 				players: ["a", "b"],
 				server: "testServer",
@@ -163,7 +164,7 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 				id: tournamentId,
 				name: "Big tournament",
 				description: "A tournament with a lot of players",
-				status: "in progress",
+				status: TournamentStatus.IPR,
 				hosts: ["testHost"],
 				players: ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
 				server: "testServer",
@@ -220,14 +221,17 @@ export class DatabaseWrapperMock implements DatabaseWrapper {
 		}
 		return [this.tournaments[0]];
 	}
-	async addPendingPlayer(channelId: string, messageId: string): Promise<DatabaseTournament | undefined> {
-		if (channelId.startsWith("wrong") || messageId.startsWith("wrong")) {
-			return;
-		}
+	async getTournamentFromMessage(): Promise<DatabaseTournament> {
 		return this.tournaments[0];
 	}
-	async removePendingPlayer(): Promise<DatabaseTournament | undefined> {
-		return this.tournaments[0];
+	async addPendingPlayer(tournamentId: string): Promise<boolean> {
+		if (tournamentId.startsWith("wrong") || tournamentId.startsWith("wrong")) {
+			return false;
+		}
+		return true;
+	}
+	async removePendingPlayer(): Promise<boolean> {
+		return true;
 	}
 	async confirmPlayer(tournamentId: string, playerId: string): Promise<void> {
 		const index = this.tournaments.findIndex(t => t.id === tournamentId);

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -124,9 +124,9 @@ describe("Tournament flow commands", function () {
 		await expect(tournament.startTournament("smallTournament")).to.be.rejectedWith(UserError);
 	});
 	it("Cancel tournament", async function () {
-		await tournament.finishTournament("tourn1", true);
+		await tournament.finishTournament("tourn2", true);
 		expect(discord.getResponse("channel1")).to.equal(
-			"Tournament 1 has been cancelled. Thank you all for playing! <@&role>\nResults: https://example.com/url"
+			"Tournament 2 has been cancelled. Thank you all for playing! <@&role>\nResults: https://example.com/url"
 		);
 	});
 	// tournament temporarily disabled because unique ID checking + top cut creation logic
@@ -137,23 +137,23 @@ describe("Tournament flow commands", function () {
 		expect(discord.getResponse("topChannel")).to.equal("Time left in the round: `50:00`"); // timer message posted after new round message
 	});
 	it("Submit score", async function () {
-		const response1 = await tournament.submitScore("tourn1", "player1", 2, 1);
+		const response1 = await tournament.submitScore("tourn2", "player1", 2, 1);
 		expect(response1).to.equal(
 			"You have reported a score of 2-1, <@player1>. Your opponent still needs to confirm this score."
 		);
-		const response2 = await tournament.submitScore("tourn1", "player1", 2, 1);
+		const response2 = await tournament.submitScore("tourn2", "player1", 2, 1);
 		expect(response2).to.equal(
 			`You have already reported your score for this match, <@player1>. Please have your opponent confirm the score.`
 		);
-		const response3 = await tournament.submitScore("tourn1", "player2", 2, 1);
+		const response3 = await tournament.submitScore("tourn2", "player2", 2, 1);
 		expect(response3).to.equal(
 			"Your score does not match your opponent's reported score of 1-2. Both of you will need to report again, <@player2>."
 		);
-		const response4 = await tournament.submitScore("tourn1", "player2", 2, 1);
+		const response4 = await tournament.submitScore("tourn2", "player2", 2, 1);
 		expect(response4).to.equal(
 			"You have reported a score of 2-1, <@player2>. Your opponent still needs to confirm this score."
 		);
-		const response5 = await tournament.submitScore("tourn1", "player1", 1, 2);
+		const response5 = await tournament.submitScore("tourn2", "player1", 1, 2);
 		expect(response5).to.equal(
 			"You have successfully reported a score of 1-2, and it matches your opponent's report, so the score has been saved. Thank you, <@player1>."
 		);
@@ -163,18 +163,18 @@ describe("Tournament flow commands", function () {
 		);
 		const response7 = discord.getResponse("channel2");
 		expect(response7).to.equal(
-			"<@player1> (player1) and <@player2> (player2) have reported their score of 1-2 for Tournament Tournament 1 (tourn1)."
+			"<@player1> (player1) and <@player2> (player2) have reported their score of 1-2 for Tournament Tournament 2 (tourn2)."
 		);
 	});
 	it("Submit score - host", async function () {
-		const response = await tournament.submitScore("tourn1", "player1", 2, 1, true);
+		const response = await tournament.submitScore("tourn2", "player1", 2, 1, true);
 		expect(response).to.equal("");
 	});
 	it(
 		"Next round",
 		test(async function (this: SinonSandbox) {
 			const createSpy = this.spy(tournament, "createPersistentTimer");
-			await tournament.nextRound("tourn1");
+			await tournament.nextRound("tourn2");
 			expect(createSpy).to.have.been.calledOnce; // new round means new timer
 		})
 	);
@@ -184,7 +184,7 @@ describe("Misc commands", function () {
 	it("List tournaments", async function () {
 		const list = await tournament.listTournaments();
 		const expectedList =
-			"ID: tourn1|Name: Tournament 1|Status: preparing|Players: 4\nID: tourn2|Name: Tournament 2|Status: preparing|Players: 3";
+			"ID: tourn1|Name: Tournament 1|Status: preparing|Players: 4\nID: tourn2|Name: Tournament 2|Status: in progress|Players: 3";
 		const testList = list.slice(0, expectedList.length);
 		expect(testList).to.equal(expectedList);
 	});

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -159,7 +159,7 @@ describe("Tournament flow commands", function () {
 		);
 		const response6 = discord.getResponse("player2");
 		expect(response6).to.equal(
-			"Your opponent has successfully confirmed your score of 2-1 for Tournament Tournament 1, so the score has been saved. Thank you."
+			"Your opponent has successfully confirmed your score of 2-1 for Tournament Tournament 2, so the score has been saved. Thank you."
 		);
 		const response7 = discord.getResponse("channel2");
 		expect(response7).to.equal(
@@ -358,7 +358,7 @@ describe("Confirm player", function () {
 			edit: noop
 		});
 		expect(response).to.equal(
-			"You're trying to update your deck for a tournament, but you're in multiple! Please choose one by dropping and registering again.\nTournament 1, Tournament 2"
+			"You're trying to update your deck for a tournament, but you're in multiple! Please choose one by dropping and registering again.\nTournament 1, Tournament 3"
 		);
 	});
 	it("Update deck", async function () {


### PR DESCRIPTION
## Description

Ensures a command cannot be used when the tournament is in an inappropriate status for that command. This also covers the registration of players.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
