### PR TITLE
Do not send reaction error messages to DMs

### DIFF
--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -251,9 +251,12 @@ export class TournamentManager implements TournamentInterface {
 		const tournaments = await this.database.getPendingTournaments(playerId);
 		if (tournaments.length > 0) {
 			await this.discord.removeUserReaction(msg.channelId, msg.id, this.CHECK_EMOJI, playerId);
-			throw new UserError(
+			// If DMs are blocked, this does end up logging by way of stack trace
+			await this.discord.sendDirectMessage(
+				playerId,
 				`You can only sign up for 1 Tournament at a time! Please either drop from or complete your registration for ${tournaments[0].name}!`
 			);
+			return;
 		}
 		// addPendingPlayer needs to status-guard for preparing tournament
 		const tournament = await this.database.addPendingPlayer(msg.channelId, msg.id, playerId);

--- a/src/discord/eris.ts
+++ b/src/discord/eris.ts
@@ -199,9 +199,8 @@ export class DiscordWrapperEris implements DiscordWrapper {
 			try {
 				await handler.response(this.wrapMessageIn(fullMsg), member.id);
 			} catch (e) {
-				if (e instanceof UserError) {
-					await this.sendDirectMessage(member.id, e.message);
-				}
+				// no errors arising here should concern the user directly,
+				// any procedural issues should be handled by a message, not throwing
 				logger.error(e);
 			}
 		}
@@ -219,9 +218,8 @@ export class DiscordWrapperEris implements DiscordWrapper {
 			try {
 				await handler.response(this.wrapMessageIn(fullMsg), userId);
 			} catch (e) {
-				if (e instanceof UserError) {
-					await this.sendDirectMessage(userId, e.message);
-				}
+				// no errors arising here should concern the user directly,
+				// any procedural issues should be handled by a message, not throwing
 				logger.error(e);
 			}
 		}


### PR DESCRIPTION
## Description

This method of error reporting is unreliable as it does not verify that the user can receive DMs, and if they can't this will throw an error of its own that is entirely unhandled and causes a crash. It is expected that reaction handlers do not use thrown errors to control user flow and so the only thrown errors are internal errors to be logged. The replacement method is a bit slap-dash but can be improved when the wrapper system is overhauled.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
