### PR TITLE
Properly handle submitting score with a closed match

### DIFF
--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -664,7 +664,7 @@ export class TournamentManager implements TournamentInterface {
 		}
 		const mention = this.discord.mentionUser(playerId); // prepare for multiple uses below
 		if (!match) {
-			return `Could not find an open match in Tournament ${tournament.name} including you, ${mention}`;
+			return `Could not find an open match in Tournament ${tournament.name} including you, ${mention}. This could mean your opponent dropped, conceding the match. If the score for your current match is incorrect, please ask a host to change it.`;
 		}
 		if (match.matchId in this.matchScores) {
 			const score = this.matchScores[match.matchId];

--- a/src/website/challonge.ts
+++ b/src/website/challonge.ts
@@ -1,6 +1,6 @@
 import { WebsiteMatch, WebsitePlayer, WebsiteTournament, WebsiteWrapper } from "./interface";
 import fetch, { Response } from "node-fetch";
-import { ChallongeAPIError } from "../util/errors";
+import { ChallongeAPIError, UserError } from "../util/errors";
 
 type TournamentType = "single elimination" | "double elimination" | "round robin" | "swiss";
 type RankedBy = "match wins" | "game wins" | "points scored" | "points difference" | "custom";
@@ -410,12 +410,18 @@ export class WebsiteWrapperChallonge implements WebsiteWrapper {
 		loserScore: number
 	): Promise<void> {
 		const webMatch = await this.indexMatches(tournamentId, "open", winner);
-		const match = webMatch[0].match;
-		const score = match.player1_id === winner ? `${winnerScore}-${loserScore}` : `${loserScore}-${winnerScore}`;
-		await this.updateMatch(tournamentId, match.id, {
-			winner_id: winnerScore === loserScore ? "tie" : winner,
-			scores_csv: score
-		});
+		if (webMatch.length > 0) {
+			const match = webMatch[0].match;
+			const score = match.player1_id === winner ? `${winnerScore}-${loserScore}` : `${loserScore}-${winnerScore}`;
+			await this.updateMatch(tournamentId, match.id, {
+				winner_id: winnerScore === loserScore ? "tie" : winner,
+				scores_csv: score
+			});
+		} else {
+			// TODO: Find a way to get the most recent closed match with that play and verify that it is in the current round.
+			// This is to enable overriding of incorrect scores.
+			throw new UserError("There is no open match for the specified player.");
+		}
 	}
 
 	private async indexPlayers(tournamentId: string): Promise<ChallongeParticipant[]> {

--- a/src/website/challonge.ts
+++ b/src/website/challonge.ts
@@ -379,12 +379,15 @@ export class WebsiteWrapperChallonge implements WebsiteWrapper {
 
 	public async getMatches(tournamentId: string): Promise<WebsiteMatch[]> {
 		const webMatches = await this.indexMatches(tournamentId, "open");
+		// don't need to check length like below function because a 0-length array is valid
 		return webMatches.map(this.wrapMatch.bind(this));
 	}
 
-	public async getMatchWithPlayer(tournamentId: string, playerId: number): Promise<WebsiteMatch> {
+	public async getMatchWithPlayer(tournamentId: string, playerId: number): Promise<WebsiteMatch | undefined> {
 		const webMatch = await this.indexMatches(tournamentId, "open", playerId);
-		return this.wrapMatch(webMatch[0]);
+		if (webMatch.length > 0) {
+			return this.wrapMatch(webMatch[0]);
+		}
 	}
 
 	private async updateMatch(


### PR DESCRIPTION
## Description

Despite TournamentManager and the WebsiteInterface assuming that `getMatchWithPlayer` would return undefined if there was no open match, that function instead assumed wrongly that it would always find an open match. (Note here that "no open match" means "most recent match is closed".) This would lead to the `submitScore` function always trying to submit a score and producing an error when the match was closed, instead of Emcee telling the user what's wrong. This PR fixes that assumption and expands the player-facing error message.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
