### PR TITLE
Tournament: Concede open match for dropping player

### DIFF
--- a/guides/player.template.md
+++ b/guides/player.template.md
@@ -18,7 +18,7 @@ In Swiss, ties are also a valid outcome:
 mc!score {}|1-1
 mc!score {}|0-0```
 **Drop**
-If you want to stop playing. If you're in the middle of a round, this will concede the current game.
+If you want to stop playing. If you're in the middle of a round, this will concede the current match.
 Be careful, this **removes you from the tournament permanently**.
 ```
 mc!drop {}```

--- a/guides/player.template.md
+++ b/guides/player.template.md
@@ -18,7 +18,7 @@ In Swiss, ties are also a valid outcome:
 mc!score {}|1-1
 mc!score {}|0-0```
 **Drop**
-If you want to stop playing.
+If you want to stop playing. If you're in the middle of a round, this will concede the current game.
 Be careful, this **removes you from the tournament permanently**.
 ```
 mc!drop {}```

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -784,8 +784,18 @@ export class TournamentManager implements TournamentInterface {
 			const match = await this.website.findMatch(tournament.id, player.challongeId);
 			// if there's no match, their most recent score is already submitted.
 			if (match) {
-				const opponent = match.player1 === player.challongeId ? match.player2 : match.player1;
-				await this.website.submitScore(tournament.id, opponent, 2, 0);
+				const oppChallonge = match.player1 === player.challongeId ? match.player2 : match.player1;
+				await this.website.submitScore(tournament.id, oppChallonge, 2, 0);
+				const opponent = tournament.players.find(p => p.challongeId === oppChallonge);
+				// should exist but checking is safer than not-null assertion
+				if (opponent) {
+					await this.discord.sendDirectMessage(
+						opponent.discordId,
+						`Your opponent ${this.discord.mentionUser(
+							player.discordId
+						)} has dropped from the tournament, conceding this round to you. You don't need to submit a score for this round.`
+					);
+				}
 			}
 		}
 		await this.website.removePlayer(tournament.id, player.challongeId);

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -714,7 +714,7 @@ export class TournamentManager implements TournamentInterface {
 			playerScore: scorePlayer,
 			oppScore: scoreOpp
 		};
-		return `You have reported a score of ${scorePlayer}-${scoreOpp}, ${mention}. Your opponent still needs to confirm this score.`;
+		return `You have reported a score of ${scorePlayer}-${scoreOpp}, ${mention}. Your opponent still needs to confirm this score. If you want to drop, please wait for your opponent to confirm or you will concede 0-2.`;
 	}
 
 	// specifically only handles telling participants about a new round

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -760,6 +760,7 @@ export class TournamentManager implements TournamentInterface {
 		if (tournament) {
 			await this.sendDropMessage(tournament, playerId, tournament.id);
 		}
+		// players can only drop by reaction when a tournament is preparing, so we don't have to worry about scores
 	}
 
 	public async dropPlayer(tournamentId: string, playerId: string, force = false): Promise<void> {
@@ -769,6 +770,7 @@ export class TournamentManager implements TournamentInterface {
 		}
 	}
 
+	// TODO: misleading function name, this command handles all drop logic after checking validity
 	private async sendDropMessage(
 		tournament: DatabaseTournament,
 		playerId: string,
@@ -777,6 +779,15 @@ export class TournamentManager implements TournamentInterface {
 	): Promise<void> {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const player = tournament.findPlayer(playerId)!;
+		// if the tournament is in progress, they may have a match we must concede on their behalf
+		if (tournament.status === TournamentStatus.IPR) {
+			const match = await this.website.findMatch(tournament.id, player.challongeId);
+			// if there's no match, their most recent score is already submitted.
+			if (match) {
+				const opponent = match.player1 === player.challongeId ? match.player2 : match.player1;
+				await this.website.submitScore(tournament.id, opponent, 2, 0);
+			}
+		}
 		await this.website.removePlayer(tournament.id, player.challongeId);
 		await this.discord.removePlayerRole(playerId, await this.discord.getPlayerRole(tournament));
 		logger.verbose(`User ${playerId} dropped from tournament ${tournament.id}${force ? " by host" : ""}.`);

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -140,7 +140,7 @@ describe("Tournament flow commands", function () {
 	it("Submit score", async function () {
 		const response1 = await tournament.submitScore("tourn2", "player1", 2, 1);
 		expect(response1).to.equal(
-			"You have reported a score of 2-1, <@player1>. Your opponent still needs to confirm this score."
+			"You have reported a score of 2-1, <@player1>. Your opponent still needs to confirm this score. If you want to drop, please wait for your opponent to confirm or you will concede 0-2."
 		);
 		const response2 = await tournament.submitScore("tourn2", "player1", 2, 1);
 		expect(response2).to.equal(
@@ -152,7 +152,7 @@ describe("Tournament flow commands", function () {
 		);
 		const response4 = await tournament.submitScore("tourn2", "player2", 2, 1);
 		expect(response4).to.equal(
-			"You have reported a score of 2-1, <@player2>. Your opponent still needs to confirm this score."
+			"You have reported a score of 2-1, <@player2>. Your opponent still needs to confirm this score. If you want to drop, please wait for your opponent to confirm or you will concede 0-2."
 		);
 		const response5 = await tournament.submitScore("tourn2", "player1", 1, 2);
 		expect(response5).to.equal(


### PR DESCRIPTION
## Description

Causes dropping a player to concede their current match if one is open. This reduces the difference in tiebreakers for a player dropping with or without submitting their match first. This does not yet handle the possibility of submitting ties or double drops.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
