### PR TITLE
Fix double entity remove resulting in SubjectWithoutIdentifierError

### DIFF
--- a/src/timer.ts
+++ b/src/timer.ts
@@ -92,7 +92,7 @@ export class PersistentTimer {
 	public async abort(): Promise<void> {
 		if (this.interval) {
 			clearInterval(this.interval);
-			this.interval === undefined;
+			this.interval = undefined;
 			try {
 				await this.entity.remove();
 			} catch (error) {


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

Occurs when the timer is aborted after it expires due to a statement with no effect.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
