### PR TITLE
Fix challonge bye detection

### DIFF
--- a/src/website/challonge.ts
+++ b/src/website/challonge.ts
@@ -426,6 +426,7 @@ export class WebsiteWrapperChallonge implements WebsiteWrapper {
 		return {
 			challongeId: player.id,
 			discordId: player.misc || "DUMMY", // Dummy players should have already been given an enumerated ID
+			active: player.active,
 			rank: player.final_rank || -1,
 			seed: player.seed
 		};

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -18,6 +18,7 @@ export interface WebsiteWrapper {
 export interface WebsitePlayer {
 	challongeId: number;
 	discordId: string;
+	active: boolean; // !dropped
 	rank: number;
 	seed: number;
 }
@@ -71,13 +72,15 @@ export class WebsiteInterface {
 
 	public async getBye(tournamentId: string): Promise<string | undefined> {
 		const tournament = await this.getTournament(tournamentId);
-		if (tournament.players.length % 2 === 0) {
+		// do not count dropped players
+		const activePlayers = tournament.players.filter(p => p.active);
+		if (activePlayers.length % 2 === 0) {
 			// even number of players means no bye
 			return undefined;
 		}
 		const matches = await this.api.getMatches(tournamentId);
 		// Find a player for which the following is true
-		const bye = tournament.players.find(p => {
+		const bye = activePlayers.find(p => {
 			// Find a match which includes the player
 			const match = matches.find(m => m.player1 === p.challongeId || m.player2 === p.challongeId);
 			// Negate: if we found a match, this player doesn't have the bye.

--- a/test/mocks/website.ts
+++ b/test/mocks/website.ts
@@ -26,6 +26,7 @@ export class WebsiteWrapperMock implements WebsiteWrapper {
 					{
 						challongeId: 1,
 						rank: -1,
+						active: true,
 						seed: 1,
 						discordId: "bye"
 					}
@@ -76,54 +77,63 @@ export class WebsiteWrapperMock implements WebsiteWrapper {
 				{
 					challongeId: 1,
 					discordId: "a",
+					active: true,
 					rank: 1,
 					seed: 1
 				},
 				{
 					challongeId: 2,
 					discordId: "b",
+					active: true,
 					rank: 2,
 					seed: 2
 				},
 				{
 					challongeId: 3,
 					discordId: "c",
+					active: true,
 					rank: 3,
 					seed: 3
 				},
 				{
 					challongeId: 4,
 					discordId: "d",
+					active: true,
 					rank: 4,
 					seed: 4
 				},
 				{
 					challongeId: 5,
 					discordId: "e",
+					active: true,
 					rank: 5,
 					seed: 5
 				},
 				{
 					challongeId: 6,
 					discordId: "f",
+					active: true,
 					rank: 6,
 					seed: 6
 				},
 				{
 					challongeId: 7,
 					discordId: "g",
+					active: true,
 					rank: 7,
 					seed: 7
 				},
 				{
 					challongeId: 8,
 					discordId: "h",
+					active: true,
 					rank: 8,
 					seed: 8
 				},
 				{
 					challongeId: 9,
 					discordId: "i",
+					active: true,
 					rank: 9,
 					seed: 9
 				}
@@ -134,12 +144,14 @@ export class WebsiteWrapperMock implements WebsiteWrapper {
 				{
 					challongeId: 1,
 					discordId: "player1",
+					active: true,
 					rank: -1,
 					seed: 1
 				},
 				{
 					challongeId: 2,
 					discordId: "dummy0",
+					active: true,
 					rank: -1,
 					seed: 2
 				}
@@ -149,6 +161,7 @@ export class WebsiteWrapperMock implements WebsiteWrapper {
 			{
 				challongeId: 1,
 				discordId: "player1",
+				active: true,
 				rank: -1,
 				seed: 1
 			}


### PR DESCRIPTION
## Description

Filters out players who have dropped so that we're only looking for a player who's still in the tournament but not playing a match this round.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
