### PR TITLE
Challonge: Update getMatches behaviour

### DIFF
--- a/src/website/challonge.ts
+++ b/src/website/challonge.ts
@@ -378,17 +378,9 @@ export class WebsiteWrapperChallonge implements WebsiteWrapper {
 		};
 	}
 
-	public async getMatches(tournamentId: string): Promise<WebsiteMatch[]> {
-		const webMatches = await this.indexMatches(tournamentId, "open");
-		// don't need to check length like below function because a 0-length array is valid
+	public async getMatches(tournamentId: string, open = false, playerId?: number): Promise<WebsiteMatch[]> {
+		const webMatches = await this.indexMatches(tournamentId, open ? "open" : undefined, playerId);
 		return webMatches.map(this.wrapMatch.bind(this));
-	}
-
-	public async getMatchWithPlayer(tournamentId: string, playerId: number): Promise<WebsiteMatch | undefined> {
-		const webMatch = await this.indexMatches(tournamentId, "open", playerId);
-		if (webMatch.length > 0) {
-			return this.wrapMatch(webMatch[0]);
-		}
 	}
 
 	private async updateMatch(

--- a/src/website/challonge.ts
+++ b/src/website/challonge.ts
@@ -380,7 +380,7 @@ export class WebsiteWrapperChallonge implements WebsiteWrapper {
 
 	public async getMatches(tournamentId: string, open = false, playerId?: number): Promise<WebsiteMatch[]> {
 		const webMatches = await this.indexMatches(tournamentId, open ? "open" : undefined, playerId);
-		return webMatches.map(this.wrapMatch.bind(this));
+		return webMatches.map(this.wrapMatch);
 	}
 
 	private async updateMatch(

--- a/src/website/challonge.ts
+++ b/src/website/challonge.ts
@@ -373,7 +373,8 @@ export class WebsiteWrapperChallonge implements WebsiteWrapper {
 		return {
 			player1: match.player1_id,
 			player2: match.player2_id,
-			matchId: match.id
+			matchId: match.id,
+			round: match.round
 		};
 	}
 

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -1,4 +1,4 @@
-import { ChallongeIDConflictError } from "../util/errors";
+import { ChallongeIDConflictError, UserError } from "../util/errors";
 
 export interface WebsiteWrapper {
 	createTournament(name: string, desc: string, url: string, topCut?: boolean): Promise<WebsiteTournament>;
@@ -100,6 +100,17 @@ export class WebsiteInterface {
 		if (matches.length > 0) {
 			return matches[0];
 		}
+	}
+
+	public async getRound(tournamentId: string): Promise<number> {
+		const matches = await this.api.getMatches(tournamentId, true);
+		if (matches.length < 1) {
+			throw new UserError(
+				`No matches found for Tournament ${tournamentId}! This likely means the tournament either has not started or is finished!`
+			);
+		}
+		// All open matches should have the same round in Swiss. In Elim, we expect the array to be sorted by age and the lowest round should be the current.
+		return matches[0].round;
 	}
 
 	public async getPlayers(tournamentId: string): Promise<WebsitePlayer[]> {

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -6,8 +6,7 @@ export interface WebsiteWrapper {
 	getTournament(tournamentId: string): Promise<WebsiteTournament>;
 	registerPlayer(tournamentId: string, playerName: string, playerId: string): Promise<number>;
 	startTournament(tournamentId: string): Promise<void>;
-	getMatches(tournamentId: string): Promise<WebsiteMatch[]>;
-	getMatchWithPlayer(tournamentId: string, playerId: number): Promise<WebsiteMatch | undefined>;
+	getMatches(tournamentId: string, open?: boolean, playerId?: number): Promise<WebsiteMatch[]>;
 	removePlayer(tournamentId: string, playerId: number): Promise<void>;
 	submitScore(tournamentId: string, winner: number, winnerScore: number, loserScore: number): Promise<void>;
 	finishTournament(tournamentId: string): Promise<void>;
@@ -91,12 +90,16 @@ export class WebsiteInterface {
 		return bye?.discordId;
 	}
 
+	// public interface is expected to get open matches
 	public async getMatches(tournamentId: string): Promise<WebsiteMatch[]> {
-		return await this.api.getMatches(tournamentId);
+		return await this.api.getMatches(tournamentId, true);
 	}
 
 	public async findMatch(tournamentId: string, playerId: number): Promise<WebsiteMatch | undefined> {
-		return await this.api.getMatchWithPlayer(tournamentId, playerId);
+		const matches = await this.api.getMatches(tournamentId, true, playerId);
+		if (matches.length > 0) {
+			return matches[0];
+		}
 	}
 
 	public async getPlayers(tournamentId: string): Promise<WebsitePlayer[]> {
@@ -209,7 +212,7 @@ export class WebsiteInterface {
 			   and this is simpler than calculating that again.
 			   This also neatly handles edge cases like a bye player being manually dropped. */
 			if (player) {
-				const match = await this.api.getMatchWithPlayer(tournamentId, player.challongeId);
+				const match = await this.findMatch(tournamentId, player.challongeId);
 				/* We assume the match will exist and be open since the tournament just started
 				   But checking handles edge cases like a human theoretically changing the score before Emcee can
 				   Considering how slow the startTournament function is, that's not impossible */

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -37,6 +37,7 @@ export interface WebsiteMatch {
 	player1: number;
 	player2: number;
 	matchId: number;
+	round: number;
 }
 
 export class WebsiteInterface {

--- a/test/mocks/website.ts
+++ b/test/mocks/website.ts
@@ -52,15 +52,18 @@ export class WebsiteWrapperMock implements WebsiteWrapper {
 	async startTournament(): Promise<void> {
 		return;
 	}
-	async getMatches(): Promise<WebsiteMatch[]> {
+	async getMatches(tournamentId: string, _?: boolean, playerId?: number): Promise<WebsiteMatch[]> {
+		if (playerId) {
+			return [
+				{
+					player1: 1,
+					player2: 2,
+					matchId: 0,
+					round: 1
+				}
+			];
+		}
 		return [];
-	}
-	async getMatchWithPlayer(): Promise<WebsiteMatch> {
-		return {
-			player1: 1,
-			player2: 2,
-			matchId: 0
-		};
 	}
 	async removePlayer(): Promise<void> {
 		return;

--- a/test/website.ts
+++ b/test/website.ts
@@ -62,7 +62,8 @@ describe("Tournament flow commands", function () {
 		expect(match).to.deep.equal({
 			player1: 1,
 			player2: 2,
-			matchId: 0
+			matchId: 0,
+			round: 1
 		});
 	});
 


### PR DESCRIPTION
## Description

This PR doesn't individually fix any issue but makes changes to enable multiple fixes and features, including `forcescore` on a closed match and restoring the round number to the new round message.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
