### PR TITLE
Don't add/remove external channels 

### DIFF
--- a/guides/create.template.md
+++ b/guides/create.template.md
@@ -2,14 +2,14 @@
 You need a public channel to start signups.
 Public channels are used for signups and pairings.
 ```
-mc!addchannel {}|public|#pairings```
+mc!addchannel {}|public```
 Private channels are used for player decks.
 ```
-mc!addchannel {}|private|#decks```
+mc!addchannel {}|private```
 You remove channels if you make a mistake.
 ```
-mc!removechannel {}|public|#pairings```
-If you don't mention a channel, it will add the current channel.
+mc!removechannel {}|public```
+These commands add the current channel.
 **Add hosts**
 Hosts have all the same permissions you do.
 Trust them like you would a moderator.

--- a/guides/create.template.md
+++ b/guides/create.template.md
@@ -9,7 +9,7 @@ mc!addchannel {}|private```
 You remove channels if you make a mistake.
 ```
 mc!removechannel {}|public```
-These commands add the current channel.
+These commands affect the current channel.
 **Add hosts**
 Hosts have all the same permissions you do.
 Trust them like you would a moderator.

--- a/src/commands/addchannel.ts
+++ b/src/commands/addchannel.ts
@@ -7,10 +7,10 @@ const command: CommandDefinition = {
 	name: "addchannel",
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
-		const [id, baseType, channelMention] = args; // 2 optional and thus potentially undefined
+		const [id, baseType] = args; // 1 optional and thus potentially undefined
 		await support.tournamentManager.authenticateHost(id, msg);
 		const type = baseType?.toLowerCase() === "private" ? "private" : "public";
-		const channelId = support.discord.getChannel(channelMention) || msg.channelId;
+		const channelId = msg.channelId;
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channelId,
@@ -19,7 +19,7 @@ const command: CommandDefinition = {
 				tournament: id,
 				command: "addchannel",
 				type,
-				destination: channelId,
+				// destination: channelId, // no longer necessary as must === channel
 				event: "attempt"
 			})
 		);
@@ -32,17 +32,16 @@ const command: CommandDefinition = {
 				tournament: id,
 				command: "addchannel",
 				type,
-				destination: channelId,
+				// destination: channelId,
 				event: "success"
 			})
 		);
+		/* No longer required as will always be in same channel as reply
 		await support.discord.sendMessage(
 			channelId,
 			`This channel added as a ${type} announcement channel for Tournament ${id}!`
-		);
-		await msg.reply(
-			`${support.discord.mentionChannel(channelId)} added as a ${type} announcement channel for Tournament ${id}!`
-		);
+		); */
+		await msg.reply(`This channel added as a ${type} announcement channel for Tournament ${id}!`);
 	}
 };
 

--- a/src/commands/removechannel.ts
+++ b/src/commands/removechannel.ts
@@ -8,10 +8,10 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		// Mirror of addchannel
-		const [id, baseType, channelMention] = args; // 2 optional and thus potentially undefined
+		const [id, baseType] = args; // 1 optional and thus potentially undefined
 		await support.tournamentManager.authenticateHost(id, msg);
 		const type = baseType?.toLowerCase() === "private" ? "private" : "public";
-		const channelId = support.discord.getChannel(channelMention) || msg.channelId;
+		const channelId = msg.channelId;
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channelId,
@@ -20,7 +20,7 @@ const command: CommandDefinition = {
 				tournament: id,
 				command: "removechannel",
 				type,
-				destination: channelId,
+				// destination: channelId,
 				event: "attempt"
 			})
 		);
@@ -33,19 +33,15 @@ const command: CommandDefinition = {
 				tournament: id,
 				command: "removechannel",
 				type,
-				destination: channelId,
+				// destination: channelId,
 				event: "success"
 			})
 		);
-		await support.discord.sendMessage(
+		/* await support.discord.sendMessage(
 			channelId,
 			`This channel removed as a ${type} announcement channel for Tournament ${id}!`
-		);
-		await msg.reply(
-			`${support.discord.mentionChannel(
-				channelId
-			)} removed as a ${type} announcement channel for Tournament ${id}!`
-		);
+		); */
+		await msg.reply(`This channel removed as a ${type} announcement channel for Tournament ${id}!`);
 	}
 };
 

--- a/src/discord/interface.ts
+++ b/src/discord/interface.ts
@@ -142,10 +142,6 @@ export class DiscordInterface {
 		);
 	}
 
-	public mentionChannel(channelId: string): string {
-		return `<#${channelId}>`;
-	}
-
 	public mentionUser(userId: string): string {
 		return `<@${userId}>`;
 	}
@@ -200,12 +196,6 @@ export class DiscordInterface {
 
 	public async deletePlayerRole(tournament: DatabaseTournament): Promise<void> {
 		await this.api.deletePlayerRole(tournament.id, tournament.server);
-	}
-
-	public getChannel(query: string): string | undefined {
-		const channelRegex = /<#(\d+?)>/g;
-		const channelMatch = channelRegex.exec(query);
-		return channelMatch ? channelMatch[1] : undefined; // capture group ensured by regex
 	}
 }
 

--- a/test/commandHandler.ts
+++ b/test/commandHandler.ts
@@ -45,61 +45,28 @@ describe("Tournament creation commands", function () {
 		const response = discord.getResponse("update");
 		expect(response).to.equal("Tournament `name` updated! It now has the name newName and the given description.");
 	});
-	it("Add channel - public/specific", async function () {
-		// channel mentions must be digits
-		await discord.simMessage("mc!addchannel name|public|<#1101>", "addchannel");
-		expect(discord.getResponse("1101")).to.equal(
-			"This channel added as a public announcement channel for Tournament name!"
-		);
-		expect(discord.getResponse("addchannel")).to.equal(
-			`${mockDiscord.mentionChannel("1101")} added as a public announcement channel for Tournament name!`
-		);
-	});
-	it("Add channel - private/default", async function () {
+	it("Add channel - private", async function () {
 		await discord.simMessage("mc!addchannel name|private", "addchannel2");
-		expect(discord.getResponse("testChannel")).to.equal(
-			"This channel added as a private announcement channel for Tournament name!"
-		);
 		expect(discord.getResponse("addchannel2")).to.equal(
-			`${mockDiscord.mentionChannel("testChannel")} added as a private announcement channel for Tournament name!`
+			`This channel added as a private announcement channel for Tournament name!`
 		);
 	});
 	it("Add channel - unspecified type", async function () {
 		await discord.simMessage("mc!addchannel name", "addchannel3");
-		expect(discord.getResponse("testChannel")).to.equal(
-			"This channel added as a public announcement channel for Tournament name!"
-		);
 		expect(discord.getResponse("addchannel3")).to.equal(
-			`${mockDiscord.mentionChannel("testChannel")} added as a public announcement channel for Tournament name!`
-		);
-	});
-	it("Remove channel - public/specified", async function () {
-		await discord.simMessage("mc!removechannel name|public|<#1102>", "remchannel");
-		expect(discord.getResponse("1102")).to.equal(
-			"This channel removed as a public announcement channel for Tournament name!"
-		);
-		expect(discord.getResponse("remchannel")).to.equal(
-			`${mockDiscord.mentionChannel("1102")} removed as a public announcement channel for Tournament name!`
+			`This channel added as a public announcement channel for Tournament name!`
 		);
 	});
 	it("Remove channel - private/default", async function () {
 		await discord.simMessage("mc!removechannel name|private", "remchannel2");
-		expect(discord.getResponse("testChannel")).to.equal(
-			"This channel removed as a private announcement channel for Tournament name!"
-		);
 		expect(discord.getResponse("remchannel2")).to.equal(
-			`${mockDiscord.mentionChannel(
-				"testChannel"
-			)} removed as a private announcement channel for Tournament name!`
+			`This channel removed as a private announcement channel for Tournament name!`
 		);
 	});
 	it("Remove channel - unspecified type", async function () {
 		await discord.simMessage("mc!removechannel name", "remchannel3");
-		expect(discord.getResponse("testChannel")).to.equal(
-			"This channel removed as a public announcement channel for Tournament name!"
-		);
 		expect(discord.getResponse("remchannel3")).to.equal(
-			`${mockDiscord.mentionChannel("testChannel")} removed as a public announcement channel for Tournament name!`
+			`This channel removed as a public announcement channel for Tournament name!`
 		);
 	});
 	it("Add host", async function () {

--- a/test/discord.ts
+++ b/test/discord.ts
@@ -29,10 +29,6 @@ describe("Simple helpers", function () {
 		await expect(discord.authenticateTO(sampleMessage)).to.not.be.rejected;
 	});
 
-	it("mentionChannel", function () {
-		expect(discord.mentionChannel("channel")).to.equal("<#channel>");
-	});
-
 	it("mentionUser", function () {
 		expect(discord.mentionUser("player")).to.equal("<@player>");
 	});
@@ -47,10 +43,6 @@ describe("Simple helpers", function () {
 
 	it("getUsername", function () {
 		expect(discord.getUsername("player1")).to.equal("player1");
-	});
-
-	it("getChannel", function () {
-		expect(discord.getChannel(sampleMessage.content)).to.equal("1101");
 	});
 });
 


### PR DESCRIPTION
## Description

This feature has quite poor security and is not worth the effort to secure. Add/remove channel commands now only operate on the current channel.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
