### PR TITLE
Remove PersistentTimer's dependency on DiscordInterface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { registerEvents } from "./events";
 import { OrganiserRoleProvider } from "./role/organiser";
 import { ParticipantRoleProvider } from "./role/participant";
 import { Templater } from "./templates";
+import { PersistentTimer, PersistentTimerDiscordDelegate } from "./timer";
 import { TournamentManager } from "./TournamentManager";
 import { getLogger } from "./util/logger";
 import { WebsiteWrapperChallonge } from "./website/challonge";
@@ -35,7 +36,14 @@ const logger = getLogger("index");
 	const discord = new DiscordInterface(eris);
 	const organiserRole = new OrganiserRoleProvider(toRole, 0x3498db);
 	const participantRole = new ParticipantRoleProvider(bot, 0xe67e22);
-	const tournamentManager = new TournamentManager(discord, database, website, templater, participantRole);
+	const delegate: PersistentTimerDiscordDelegate = {
+		sendMessage: async (...args) => (await bot.createMessage(...args)).id,
+		editMessage: async (...args) => void (await bot.editMessage(...args))
+	};
+	const tournamentManager = new TournamentManager(discord, database, website, templater, participantRole, {
+		create: async (...args) => await PersistentTimer.create(delegate, ...args),
+		loadAll: async () => await PersistentTimer.loadAll(delegate)
+	});
 	registerEvents(bot, prefix, { discord, tournamentManager, organiserRole }, database, website);
 	discord.onDelete(msg => tournamentManager.cleanRegistration(msg));
 

--- a/test/timer.ts
+++ b/test/timer.ts
@@ -3,16 +3,18 @@ import proxyquire from "proxyquire";
 import sinon, { SinonSandbox } from "sinon";
 import sinonChai from "sinon-chai";
 import sinonTest from "sinon-test";
-import { DiscordInterface } from "../src/discord/interface";
-import { DiscordWrapperMock } from "./mocks/discord";
 
 chai.use(sinonChai);
 const test = sinonTest(sinon);
 proxyquire.noPreserveCache();
 
-const discordMock = new DiscordWrapperMock();
-const discord = new DiscordInterface(discordMock);
-
+// The external dependencies that we specifically mock out.
+const send = sinon.stub().resolves("testId");
+const edit = sinon.spy();
+const discordDelegateMock = {
+	sendMessage: send,
+	editMessage: edit
+};
 const countdownEntityStub = {
 	save: sinon.stub(),
 	remove: sinon.stub()
@@ -21,8 +23,11 @@ const Countdown = sinon.stub().returns(countdownEntityStub);
 const { PersistentTimer } = proxyquire("../src/timer", {
 	"./database/orm": { Countdown }
 });
+// The strong disadvantage of the proxyquire approach is that we lose all type-safety in tests.
+// Therefore I would not recommend it for other tests, especially if they get more complex than this.
 
 describe("PersistentTimer is a timer", function () {
+	// Ensures that each test does not affect the other when they use the same mocks declared above.
 	beforeEach(function () {
 		sinon.resetHistory();
 	});
@@ -30,94 +35,60 @@ describe("PersistentTimer is a timer", function () {
 	it(
 		"initializes correctly",
 		test(async function (this: SinonSandbox) {
-			const sendMessageSpy = this.spy(discord, "sendMessage"); // TODO: replace when we mock Discord the same way
 			const timer = await PersistentTimer.create(
-				discord,
+				discordDelegateMock,
 				new Date(Date.now() + 10000),
 				"1234567890",
 				"Test timer done",
 				5
 			);
 			expect(timer.isActive()).to.be.true;
-			expect(sendMessageSpy).to.have.been.calledWith("1234567890", "Time left in the round: `00:10`");
+			expect(send).to.have.been.calledWith("1234567890", "Time left in the round: `00:10`");
 			expect(Countdown).to.have.been.called;
 			expect(countdownEntityStub.save).to.have.been.called;
-			expect(sendMessageSpy).to.have.been.calledBefore(countdownEntityStub.save);
+			expect(send).to.have.been.calledBefore(countdownEntityStub.save);
 		})
 	);
 
 	it(
 		"calls tick and finishes",
 		test(async function (this: SinonSandbox) {
-			const sendMessageSpy = this.spy(discord, "sendMessage"); // TODO: replace when we mock Discord the same way
-			const edit = this.stub();
-			const getMessageStub = this.stub(discord, "getMessage").returns(
-				Promise.resolve({
-					id: "",
-					content: "",
-					attachments: [],
-					author: "",
-					channelId: "",
-					serverId: "",
-					reply: this.stub(),
-					react: this.stub(),
-					edit
-				})
-			);
 			const timer = await PersistentTimer.create(
-				discord,
+				discordDelegateMock,
 				new Date(Date.now() + 15000),
 				"1234567890",
 				"Test timer done",
 				5
 			);
-			void timer;
 			// Tick should be every second
 			await this.clock.tickAsync(500);
 			expect(edit).to.not.have.been.called;
 			// First tick
 			await this.clock.tickAsync(4500);
-			expect(edit).to.have.been.calledOnceWith("Time left in the round: `00:10`");
+			expect(edit).to.have.been.calledOnceWith("1234567890", "testId", "Time left in the round: `00:10`");
 			// Second tick
 			await this.clock.tickAsync(5000);
 			expect(edit).to.have.been.calledTwice;
-			expect(edit).to.have.been.calledWith("Time left in the round: `00:05`");
+			expect(edit).to.have.been.calledWith("1234567890", "testId", "Time left in the round: `00:05`");
 			// Third tick, we should be finished
 			await this.clock.tickAsync(5000);
 			expect(edit).to.have.been.calledThrice;
-			expect(edit).to.have.been.calledWith("Time left in the round: `00:00`");
-			expect(sendMessageSpy).to.have.been.calledWith("1234567890", "Test timer done");
+			expect(edit).to.have.been.calledWith("1234567890", "testId", "Time left in the round: `00:00`");
+			expect(send).to.have.been.calledWith("1234567890", "Test timer done");
 			expect(countdownEntityStub.remove).to.have.been.called;
 			// Nothing else should happen now
 			await this.clock.runAllAsync();
 			expect(edit).to.have.been.calledThrice;
 			expect(countdownEntityStub.remove).to.have.been.calledOnce.and.calledOn(countdownEntityStub);
-			// This message id is from the "mock" DiscordWrapper. We would use a stub otherwise.
-			expect(getMessageStub).to.have.been.calledWithExactly("1234567890", "testId");
+			expect(timer.isActive()).to.be.false;
 		})
 	);
 
 	it(
 		"can be aborted",
 		test(async function (this: SinonSandbox) {
-			const sendMessageSpy = this.spy(discord, "sendMessage"); // TODO: replace when we mock Discord the same way
-			const edit = this.stub();
-			const getMessageStub = this.stub(discord, "getMessage").returns(
-				Promise.resolve({
-					id: "",
-					content: "",
-					attachments: [],
-					author: "",
-					channelId: "",
-					serverId: "",
-					reply: this.stub(),
-					react: this.stub(),
-					edit
-				})
-			);
-			void getMessageStub;
 			const timer = await PersistentTimer.create(
-				discord,
+				discordDelegateMock,
 				new Date(Date.now() + 3000),
 				"1234567890",
 				"Test timer done",
@@ -133,7 +104,7 @@ describe("PersistentTimer is a timer", function () {
 			await this.clock.runAllAsync();
 			expect(edit).to.have.been.calledOnce;
 			// No final message sent
-			expect(sendMessageSpy).to.have.been.calledOnce;
+			expect(send).to.have.been.calledOnce;
 		})
 	);
 });

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -29,17 +29,6 @@ const persistentTimerStub = ({
 	abort: () => undefined
 } as unknown) as PersistentTimer;
 
-/// Override link seams for test fakes
-class TournamentManagerTest extends TournamentManager {
-	public async createPersistentTimer(): ReturnType<typeof PersistentTimer.create> {
-		return persistentTimerStub;
-	}
-
-	public async loadPersistentTimers(): ReturnType<typeof PersistentTimer.loadAll> {
-		return [];
-	}
-}
-
 const discord = new DiscordWrapperMock(); // will be used to fetch responses in some cases
 const mockDiscord = new DiscordInterface(discord);
 
@@ -56,7 +45,10 @@ sinon.stub(participantRole, "grant").resolves();
 sinon.stub(participantRole, "ungrant").resolves();
 sinon.stub(participantRole, "delete").resolves();
 
-const tournament = new TournamentManagerTest(mockDiscord, mockDb, mockWebsite, templater, participantRole);
+const tournament = new TournamentManager(mockDiscord, mockDb, mockWebsite, templater, participantRole, {
+	create: async () => persistentTimerStub,
+	loadAll: async () => []
+});
 
 before(async () => {
 	await initializeCardArray();

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -2,14 +2,12 @@ import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { Client } from "eris";
 import * as fs from "fs/promises";
-import sinon, { SinonSandbox } from "sinon";
+import sinon from "sinon";
 import sinonChai from "sinon-chai";
-import sinonTest from "sinon-test";
 import { initializeCardArray } from "../src/deck/deck";
 import { DiscordAttachmentOut, DiscordEmbed, DiscordInterface, DiscordMessageOut } from "../src/discord/interface";
 import { ParticipantRoleProvider } from "../src/role/participant";
 import { Templater } from "../src/templates";
-import { PersistentTimer } from "../src/timer";
 import { TournamentManager } from "../src/TournamentManager";
 import { UserError } from "../src/util/errors";
 import { WebsiteInterface } from "../src/website/interface";
@@ -19,15 +17,6 @@ import { WebsiteWrapperMock } from "./mocks/website";
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
-const test = sinonTest(sinon);
-
-// Unfortunately, TypeScript considers private and protected members
-// necessary for the type definition as well, so we force a cast
-const persistentTimerStub = ({
-	tournament: undefined,
-	isActive: () => true,
-	abort: () => undefined
-} as unknown) as PersistentTimer;
 
 const discord = new DiscordWrapperMock(); // will be used to fetch responses in some cases
 const mockDiscord = new DiscordInterface(discord);
@@ -45,10 +34,15 @@ sinon.stub(participantRole, "grant").resolves();
 sinon.stub(participantRole, "ungrant").resolves();
 sinon.stub(participantRole, "delete").resolves();
 
-const tournament = new TournamentManager(mockDiscord, mockDb, mockWebsite, templater, participantRole, {
-	create: async () => persistentTimerStub,
+const delegate = {
+	create: sinon.stub().resolves({
+		tournament: undefined,
+		isActive: () => true,
+		abort: () => undefined
+	}),
 	loadAll: async () => []
-});
+};
+const tournament = new TournamentManager(mockDiscord, mockDb, mockWebsite, templater, participantRole, delegate);
 
 before(async () => {
 	await initializeCardArray();
@@ -101,14 +95,11 @@ describe("Tournament flow commands", function () {
 	it("Open tournament - no channels", async function () {
 		await expect(tournament.openTournament("smallTournament")).to.be.rejectedWith(UserError);
 	});
-	it(
-		"Start tournament",
-		test(async function (this: SinonSandbox) {
-			const createSpy = this.spy(tournament, "createPersistentTimer");
-			await tournament.startTournament("tourn1");
-			expect(createSpy).to.have.been.calledOnce;
-		})
-	);
+	it("Start tournament", async function () {
+		delegate.create.resetHistory();
+		await tournament.startTournament("tourn1");
+		expect(delegate.create).to.have.been.calledOnce;
+	});
 	// I have no idea what this test was meant to do
 	it.skip("Start tournament - with bye", async function () {
 		await tournament.startTournament("byeTournament");
@@ -171,14 +162,11 @@ describe("Tournament flow commands", function () {
 		const response = await tournament.submitScoreForce("tourn2", "player1", 2, 1);
 		expect(response).to.equal("Score of 2-1 submitted in favour of <@player1> (player1) in Tournament tourn2!");
 	});
-	it(
-		"Next round",
-		test(async function (this: SinonSandbox) {
-			const createSpy = this.spy(tournament, "createPersistentTimer");
-			await tournament.nextRound("tourn2");
-			expect(createSpy).to.have.been.calledOnce; // new round means new timer
-		})
-	);
+	it("Next round", async function () {
+		delegate.create.resetHistory();
+		await tournament.nextRound("tourn2");
+		expect(delegate.create).to.have.been.calledOnce; // new round means new timer
+	});
 });
 
 describe("Misc commands", function () {


### PR DESCRIPTION
## Description

Part of #161. ~I think even the intermediate code can be removed from TournamentManager; instead of the link seams, the two key functions can be dependencies, so that the delegate can directly call Eris instead of another level of indirection through DiscordInterface, which might be worthwhile depending on how long TournamentManager sticks around without being ripped up.~ 

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
