### PR TITLE
Handle double drops on guildMemberRemove

### DIFF
--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -452,6 +452,15 @@ export class DatabaseWrapperPostgres {
 			deck: p.deck
 		};
 	}
+
+	async getPlayerByChallonge(challongeId: number, tournamentId: string): Promise<DatabasePlayer> {
+		const p = await ConfirmedParticipant.findOneOrFail({ challongeId, tournamentId });
+		return {
+			discordId: p.discordId,
+			challongeId: p.challongeId,
+			deck: p.deck
+		};
+	}
 }
 
 export async function initializeDatabase(postgresqlUrl: string): Promise<DatabaseWrapperPostgres> {

--- a/test/mocks/database.ts
+++ b/test/mocks/database.ts
@@ -305,4 +305,7 @@ export class DatabaseWrapperMock {
 	getConfirmedPlayer(): Promise<DatabasePlayer> {
 		throw new Error("Not implemented");
 	}
+	getPlayerByChallonge(): Promise<DatabasePlayer> {
+		throw new Error("Not implemented");
+	}
 }


### PR DESCRIPTION
## Description

- Add DatabaseWrapperPostgres.getPlayerByChallonge
- Reduce how many lines log calls take up
- Fix potential crash at findMatch, now findClosedMatch

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
