### PR TITLE
Extract simple commands from TournamentManager

### DIFF
--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -25,8 +25,6 @@ export interface TournamentInterface {
 	confirmPlayer(msg: DiscordMessageIn): Promise<void>;
 	cleanRegistration(msg: DiscordMessageLimited): Promise<void>;
 	createTournament(hostId: string, serverId: string, name: string, desc: string): Promise<[string, string, string]>;
-	addHost(tournamentId: string, newHost: string): Promise<void>;
-	removeHost(tournamentId: string, newHost: string): Promise<void>;
 	openTournament(tournamentId: string): Promise<void>;
 	startTournament(tournamentId: string): Promise<void>;
 	finishTournament(tournamentId: string, cancel: boolean | undefined): Promise<void>;
@@ -146,14 +144,6 @@ export class TournamentManager implements TournamentInterface {
 		const web = await this.website.createTournament(name, desc, candidateUrl, topCut);
 		await this.database.createTournament(hostId, serverId, web.id, name, desc);
 		return [web.id, web.url, this.templater.format("create", web.id)];
-	}
-
-	public async addHost(tournamentId: string, newHost: string): Promise<void> {
-		await this.database.addHost(tournamentId, newHost);
-	}
-
-	public async removeHost(tournamentId: string, newHost: string): Promise<void> {
-		await this.database.removeHost(tournamentId, newHost);
 	}
 
 	private async handleDmFailure(playerId: string, tournament: DatabaseTournament): Promise<void> {

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -24,8 +24,6 @@ export interface TournamentInterface {
 	registerPlayer(msg: DiscordMessageIn, playerId: string): Promise<void>;
 	confirmPlayer(msg: DiscordMessageIn): Promise<void>;
 	cleanRegistration(msg: DiscordMessageLimited): Promise<void>;
-	authenticateHost(tournamentId: string, userId: string): Promise<void>;
-	authenticatePlayer(tournamentId: string, userId: string): Promise<void>;
 	listTournaments(server?: string): Promise<string>;
 	createTournament(hostId: string, serverId: string, name: string, desc: string): Promise<[string, string, string]>;
 	updateTournament(tournamentId: string, name: string, desc: string): Promise<void>;
@@ -101,14 +99,6 @@ export class TournamentManager implements TournamentInterface {
 			}
 		}
 		logger.info(`Loaded ${count} of ${messages.length} reaction buttons.`);
-	}
-
-	public async authenticateHost(tournamentId: string, userId: string): Promise<void> {
-		await this.database.authenticateHost(tournamentId, userId);
-	}
-
-	public async authenticatePlayer(tournamentId: string, userId: string): Promise<void> {
-		await this.database.authenticatePlayer(tournamentId, userId);
 	}
 
 	public async listTournaments(server?: string): Promise<string> {

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -25,7 +25,6 @@ export interface TournamentInterface {
 	confirmPlayer(msg: DiscordMessageIn): Promise<void>;
 	cleanRegistration(msg: DiscordMessageLimited): Promise<void>;
 	createTournament(hostId: string, serverId: string, name: string, desc: string): Promise<[string, string, string]>;
-	updateTournament(tournamentId: string, name: string, desc: string): Promise<void>;
 	addHost(tournamentId: string, newHost: string): Promise<void>;
 	removeHost(tournamentId: string, newHost: string): Promise<void>;
 	openTournament(tournamentId: string): Promise<void>;
@@ -147,12 +146,6 @@ export class TournamentManager implements TournamentInterface {
 		const web = await this.website.createTournament(name, desc, candidateUrl, topCut);
 		await this.database.createTournament(hostId, serverId, web.id, name, desc);
 		return [web.id, web.url, this.templater.format("create", web.id)];
-	}
-
-	public async updateTournament(tournamentId: string, name: string, desc: string): Promise<void> {
-		// Update DB first because it performs an important check that might throw
-		await this.database.updateTournament(tournamentId, name, desc);
-		await this.website.updateTournament(tournamentId, name, desc);
 	}
 
 	public async addHost(tournamentId: string, newHost: string): Promise<void> {

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -1,5 +1,5 @@
 import { Deck } from "ydeck";
-import { DatabasePlayer, DatabaseTournament, TournamentStatus } from "./database/interface";
+import { DatabaseTournament, TournamentStatus } from "./database/interface";
 import { DatabaseWrapperPostgres } from "./database/postgres";
 import { getDeck } from "./deck/deck";
 import { getDeckFromMessage, prettyPrint } from "./deck/discordDeck";
@@ -31,7 +31,6 @@ export interface TournamentInterface {
 	nextRound(tournamentId: string, skip?: boolean): Promise<void>;
 	getPlayerDeck(tournamentId: string, playerId: string): Promise<Deck>;
 	dropPlayer(tournamentId: string, playerId: string, force?: boolean): Promise<void>;
-	getConfirmed(tournamentId: string): Promise<DatabasePlayer[]>;
 }
 
 type Public<T> = Pick<T, keyof T>;
@@ -668,10 +667,5 @@ export class TournamentManager implements TournamentInterface {
 		for (const m of messages) {
 			await this.discord.removeUserReaction(m.channelId, m.messageId, this.CHECK_EMOJI, playerId);
 		}
-	}
-
-	public async getConfirmed(tournamentId: string): Promise<DatabasePlayer[]> {
-		const tournament = await this.database.getTournament(tournamentId);
-		return tournament.players;
 	}
 }

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -41,8 +41,6 @@ export interface TournamentInterface {
 	dropPlayer(tournamentId: string, playerId: string, force?: boolean): Promise<void>;
 	syncTournament(tournamentId: string): Promise<void>;
 	getConfirmed(tournamentId: string): Promise<DatabasePlayer[]>;
-	registerBye(tournamentId: string, playerId: string): Promise<string[]>;
-	removeBye(tournamentId: string, playerId: string): Promise<string[]>;
 }
 
 type Public<T> = Pick<T, keyof T>;
@@ -737,13 +735,5 @@ export class TournamentManager implements TournamentInterface {
 	public async getConfirmed(tournamentId: string): Promise<DatabasePlayer[]> {
 		const tournament = await this.database.getTournament(tournamentId);
 		return tournament.players;
-	}
-
-	public async registerBye(tournamentId: string, playerId: string): Promise<string[]> {
-		return await this.database.registerBye(tournamentId, playerId);
-	}
-
-	public async removeBye(tournamentId: string, playerId: string): Promise<string[]> {
-		return await this.database.removeBye(tournamentId, playerId);
 	}
 }

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -24,7 +24,6 @@ export interface TournamentInterface {
 	registerPlayer(msg: DiscordMessageIn, playerId: string): Promise<void>;
 	confirmPlayer(msg: DiscordMessageIn): Promise<void>;
 	cleanRegistration(msg: DiscordMessageLimited): Promise<void>;
-	listTournaments(server?: string): Promise<string>;
 	createTournament(hostId: string, serverId: string, name: string, desc: string): Promise<[string, string, string]>;
 	updateTournament(tournamentId: string, name: string, desc: string): Promise<void>;
 	addHost(tournamentId: string, newHost: string): Promise<void>;
@@ -99,12 +98,6 @@ export class TournamentManager implements TournamentInterface {
 			}
 		}
 		logger.info(`Loaded ${count} of ${messages.length} reaction buttons.`);
-	}
-
-	public async listTournaments(server?: string): Promise<string> {
-		const list = await this.database.getActiveTournaments(server);
-		const text = list.map(t => `ID: ${t.id}|Name: ${t.name}|Status: ${t.status}|Players: ${t.players.length}`);
-		return text.join("\n");
 	}
 
 	private async checkUrlTaken(url: string): Promise<boolean> {

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -31,7 +31,6 @@ export interface TournamentInterface {
 	nextRound(tournamentId: string, skip?: boolean): Promise<void>;
 	getPlayerDeck(tournamentId: string, playerId: string): Promise<Deck>;
 	dropPlayer(tournamentId: string, playerId: string, force?: boolean): Promise<void>;
-	syncTournament(tournamentId: string): Promise<void>;
 	getConfirmed(tournamentId: string): Promise<DatabasePlayer[]>;
 }
 
@@ -669,15 +668,6 @@ export class TournamentManager implements TournamentInterface {
 		for (const m of messages) {
 			await this.discord.removeUserReaction(m.channelId, m.messageId, this.CHECK_EMOJI, playerId);
 		}
-	}
-
-	public async syncTournament(tournamentId: string): Promise<void> {
-		const tournamentData = await this.website.getTournament(tournamentId);
-		await this.database.synchronise(tournamentId, {
-			name: tournamentData.name,
-			description: tournamentData.desc,
-			players: tournamentData.players.map(({ challongeId, discordId }) => ({ challongeId, discordId }))
-		});
 	}
 
 	public async getConfirmed(tournamentId: string): Promise<DatabasePlayer[]> {

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -29,8 +29,6 @@ export interface TournamentInterface {
 	listTournaments(server?: string): Promise<string>;
 	createTournament(hostId: string, serverId: string, name: string, desc: string): Promise<[string, string, string]>;
 	updateTournament(tournamentId: string, name: string, desc: string): Promise<void>;
-	addAnnouncementChannel(tournamentId: string, channelId: string, type: "public" | "private"): Promise<void>;
-	removeAnnouncementChannel(tournamentId: string, channelId: string, type: "public" | "private"): Promise<void>;
 	addHost(tournamentId: string, newHost: string): Promise<void>;
 	removeHost(tournamentId: string, newHost: string): Promise<void>;
 	openTournament(tournamentId: string): Promise<void>;
@@ -172,22 +170,6 @@ export class TournamentManager implements TournamentInterface {
 		// Update DB first because it performs an important check that might throw
 		await this.database.updateTournament(tournamentId, name, desc);
 		await this.website.updateTournament(tournamentId, name, desc);
-	}
-
-	public async addAnnouncementChannel(
-		tournamentId: string,
-		channelId: string,
-		type: "public" | "private"
-	): Promise<void> {
-		await this.database.addAnnouncementChannel(tournamentId, channelId, type);
-	}
-
-	public async removeAnnouncementChannel(
-		tournamentId: string,
-		channelId: string,
-		type: "public" | "private"
-	): Promise<void> {
-		await this.database.removeAnnouncementChannel(tournamentId, channelId, type);
 	}
 
 	public async addHost(tournamentId: string, newHost: string): Promise<void> {

--- a/src/commands/addbye.ts
+++ b/src/commands/addbye.ts
@@ -22,7 +22,7 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		const byes = await support.tournamentManager.registerBye(id, player);
+		const byes = await support.database.registerBye(id, player);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/addbye.ts
+++ b/src/commands/addbye.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		const player = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/addchannel.ts
+++ b/src/commands/addchannel.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id, baseType] = args; // 1 optional and thus potentially undefined
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		const type = baseType?.toLowerCase() === "private" ? "private" : "public";
 		const channelId = msg.channel.id;
 		logger.verbose(

--- a/src/commands/addchannel.ts
+++ b/src/commands/addchannel.ts
@@ -24,7 +24,7 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		await support.tournamentManager.addAnnouncementChannel(id, channelId, type);
+		await support.database.addAnnouncementChannel(id, channelId, type);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/addhost.ts
+++ b/src/commands/addhost.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		const newHost = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/addhost.ts
+++ b/src/commands/addhost.ts
@@ -22,7 +22,7 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		await support.tournamentManager.addHost(id, newHost);
+		await support.database.addHost(id, newHost);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/cancel.ts
+++ b/src/commands/cancel.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// This executor's logic is now surprisingly similar to finish
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/deck.ts
+++ b/src/commands/deck.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		const player = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/drop.ts
+++ b/src/commands/drop.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// TODO: infer tournamentId from tournament player is in? gotta make player-facing features as simple as possible
 		const [id] = args;
-		await support.tournamentManager.authenticatePlayer(id, msg.author.id);
+		await support.database.authenticatePlayer(id, msg.author.id);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/dump.ts
+++ b/src/commands/dump.ts
@@ -11,7 +11,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/dump.ts
+++ b/src/commands/dump.ts
@@ -22,7 +22,7 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		const players = await support.tournamentManager.getConfirmed(id);
+		const players = await support.database.getConfirmed(id);
 		const rows = players.map(player => {
 			const deck = getDeck(player.deck);
 			return {

--- a/src/commands/finish.ts
+++ b/src/commands/finish.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/forcedrop.ts
+++ b/src/commands/forcedrop.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id", "who"],
 	executor: async (msg, args, support) => {
 		const [id, who] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		const player = who.startsWith("<@!") && who.endsWith(">") ? who.slice(3, -1) : who;
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -20,7 +20,10 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		const list = await support.tournamentManager.listTournaments(msg.guildID || "private");
+		const list = await support.database.getActiveTournaments(msg.guildID || "private");
+		const text = list
+			.map(t => `ID: ${t.id}|Name: ${t.name}|Status: ${t.status}|Players: ${t.players.length}`)
+			.join("\n");
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,
@@ -30,10 +33,10 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		if (list.length === 0) {
+		if (text.length === 0) {
 			await reply(msg, "There are no open tournaments you have access to!");
 		} else {
-			await reply(msg, `\`\`\`\n${list}\`\`\``);
+			await reply(msg, `\`\`\`\n${text}\`\`\``);
 		}
 	}
 };

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/pie.ts
+++ b/src/commands/pie.ts
@@ -22,7 +22,7 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		const players = await support.tournamentManager.getConfirmed(id);
+		const players = await support.database.getConfirmed(id);
 		// TODO: benchmark performance of map-reduce
 		const themes = players
 			.map(player => {

--- a/src/commands/pie.ts
+++ b/src/commands/pie.ts
@@ -11,7 +11,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/players.ts
+++ b/src/commands/players.ts
@@ -11,7 +11,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/players.ts
+++ b/src/commands/players.ts
@@ -22,7 +22,7 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		const players = await support.tournamentManager.getConfirmed(id);
+		const players = await support.database.getConfirmed(id);
 		const rows = players.map(player => {
 			const deck = getDeck(player.deck);
 			return {

--- a/src/commands/removebye.ts
+++ b/src/commands/removebye.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// Mirror of addbye
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		const player = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/removebye.ts
+++ b/src/commands/removebye.ts
@@ -23,7 +23,7 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		const byes = await support.tournamentManager.removeBye(id, player);
+		const byes = await support.database.removeBye(id, player);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/removechannel.ts
+++ b/src/commands/removechannel.ts
@@ -25,7 +25,7 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		await support.tournamentManager.removeAnnouncementChannel(id, channelId, type);
+		await support.database.removeAnnouncementChannel(id, channelId, type);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/removechannel.ts
+++ b/src/commands/removechannel.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// Mirror of addchannel
 		const [id, baseType] = args; // 1 optional and thus potentially undefined
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		const type = baseType?.toLowerCase() === "private" ? "private" : "public";
 		const channelId = msg.channel.id;
 		logger.verbose(

--- a/src/commands/removehost.ts
+++ b/src/commands/removehost.ts
@@ -23,7 +23,7 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		await support.tournamentManager.removeHost(id, newHost);
+		await support.database.removeHost(id, newHost);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/removehost.ts
+++ b/src/commands/removehost.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// Mirror of addhost
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		const newHost = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/round.ts
+++ b/src/commands/round.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id, skip] = args; // second is optional and may be undefined
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -20,7 +20,12 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		await support.tournamentManager.syncTournament(id);
+		const tournamentData = await support.challonge.getTournament(id);
+		await support.database.synchronise(id, {
+			name: tournamentData.name,
+			description: tournamentData.desc,
+			players: tournamentData.players.map(({ challongeId, discordId }) => ({ challongeId, discordId }))
+		});
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -22,7 +22,9 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
-		await support.tournamentManager.updateTournament(id, name, desc);
+		// Update DB first because it performs an important check that might throw
+		await support.database.updateTournament(id, name, desc);
+		await support.challonge.updateTournament(id, name, desc);
 		// TODO: missing failure path
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id", "name", "description"],
 	executor: async (msg, args, support) => {
 		const [id, name, desc] = args;
-		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -444,6 +444,12 @@ export class DatabaseWrapperPostgres {
 		});
 	}
 
+	async getConfirmed(tournamentId: string): Promise<DatabasePlayer[]> {
+		// is this how to use select properly? it seems off that it still returns a full tournament object
+		const players = await ChallongeTournament.findOneOrFail(tournamentId, { select: ["confirmed"] });
+		return players.confirmed;
+	}
+
 	async getConfirmedPlayer(discordId: string, tournamentId: string): Promise<DatabasePlayer> {
 		const p = await ConfirmedParticipant.findOneOrFail({ discordId, tournamentId });
 		return {

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -445,9 +445,7 @@ export class DatabaseWrapperPostgres {
 	}
 
 	async getConfirmed(tournamentId: string): Promise<DatabasePlayer[]> {
-		// is this how to use select properly? it seems off that it still returns a full tournament object
-		const players = await ChallongeTournament.findOneOrFail(tournamentId, { select: ["confirmed"] });
-		return players.confirmed;
+		return await ConfirmedParticipant.find({ tournamentId });
 	}
 
 	async getConfirmedPlayer(discordId: string, tournamentId: string): Promise<DatabasePlayer> {

--- a/test/commands/addbye.unit.ts
+++ b/test/commands/addbye.unit.ts
@@ -17,7 +17,7 @@ describe("command:addbye", function () {
 		test(async function (this: SinonSandbox) {
 			msg.mentions = [new User({ id: "nova" }, mockBotClient)];
 			msg.channel.createMessage = this.spy();
-			this.stub(support.tournamentManager, "registerBye").resolves([]);
+			this.stub(support.database, "registerBye").resolves([]);
 			await command.executor(msg, ["name"], support);
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
 				"Bye registered for Player <@nova> (nova) in Tournament name!\nAll byes: "

--- a/test/commands/addchannel.unit.ts
+++ b/test/commands/addchannel.unit.ts
@@ -1,29 +1,56 @@
 import { expect } from "chai";
-import sinon from "sinon";
+import { SinonSandbox } from "sinon";
 import command from "../../src/commands/addchannel";
-import { itRejectsNonHosts, msg, support } from "./common";
+import { itRejectsNonHosts, msg, support, test } from "./common";
 
 describe("command:addchannel", function () {
 	itRejectsNonHosts(support, command, msg, ["name"]);
-	it("adds a public channel by default", async () => {
-		msg.channel.createMessage = sinon.spy();
-		await command.executor(msg, ["name"], support);
-		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			"This channel added as a public announcement channel for Tournament name!"
-		);
-	});
-	it("adds public channels", async () => {
-		msg.channel.createMessage = sinon.spy();
-		await command.executor(msg, ["name", "public"], support);
-		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			"This channel added as a public announcement channel for Tournament name!"
-		);
-	});
-	it("adds private channels", async () => {
-		msg.channel.createMessage = sinon.spy();
-		await command.executor(msg, ["name", "private"], support);
-		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			"This channel added as a private announcement channel for Tournament name!"
-		);
-	});
+	it(
+		"adds a public channel by default",
+		test(async function (this: SinonSandbox) {
+			msg.channel.createMessage = this.spy();
+			this.stub(support.database, "addAnnouncementChannel");
+			await command.executor(msg, ["name"], support);
+			expect(support.database.addAnnouncementChannel).to.have.been.calledOnceWithExactly(
+				"name",
+				msg.channel.id,
+				"public"
+			);
+			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
+				"This channel added as a public announcement channel for Tournament name!"
+			);
+		})
+	);
+	it(
+		"adds public channels",
+		test(async function (this: SinonSandbox) {
+			msg.channel.createMessage = this.spy();
+			this.stub(support.database, "addAnnouncementChannel");
+			await command.executor(msg, ["name", "public"], support);
+			expect(support.database.addAnnouncementChannel).to.have.been.calledOnceWithExactly(
+				"name",
+				msg.channel.id,
+				"public"
+			);
+			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
+				"This channel added as a public announcement channel for Tournament name!"
+			);
+		})
+	);
+	it(
+		"adds private channels",
+		test(async function (this: SinonSandbox) {
+			msg.channel.createMessage = this.spy();
+			this.stub(support.database, "addAnnouncementChannel");
+			await command.executor(msg, ["name", "private"], support);
+			expect(support.database.addAnnouncementChannel).to.have.been.calledOnceWithExactly(
+				"name",
+				msg.channel.id,
+				"private"
+			);
+			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
+				"This channel added as a private announcement channel for Tournament name!"
+			);
+		})
+	);
 });

--- a/test/commands/common.ts
+++ b/test/commands/common.ts
@@ -26,7 +26,7 @@ export function itRejectsNonHosts(
 	it(
 		"rejects non-hosts",
 		test(function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").rejects();
+			const authStub = this.stub(support.database, "authenticateHost").rejects();
 			msg.channel.createMessage = sinon.spy();
 			expect(command.executor(msg, args, support)).to.be.rejected;
 			expect(authStub).to.have.been.called;

--- a/test/commands/drop.unit.ts
+++ b/test/commands/drop.unit.ts
@@ -7,7 +7,7 @@ describe("command:drop", function () {
 	it(
 		"rejects non-players",
 		test(function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticatePlayer").rejects();
+			const authStub = this.stub(support.database, "authenticatePlayer").rejects();
 			msg.channel.createMessage = this.spy();
 			expect(command.executor(msg, ["name"], support)).to.be.rejected;
 			expect(authStub).to.have.been.calledOnceWithExactly("name", "0000");

--- a/test/commands/dump.unit.ts
+++ b/test/commands/dump.unit.ts
@@ -15,7 +15,7 @@ describe("command:dump", function () {
 		"provides a dump of all decks",
 		test(async function (this: SinonSandbox) {
 			const authStub = this.stub(support.database, "authenticateHost").resolves();
-			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([
+			const listStub = this.stub(support.database, "getConfirmed").resolves([
 				{ discordId: "1312", deck: "ydke://!!!", challongeId: 1 },
 				{ discordId: "1314", deck: "ydke://!!!", challongeId: 2 },
 				{ discordId: "1234", deck: "ydke://!!!", challongeId: 3 }
@@ -41,7 +41,7 @@ describe("command:dump", function () {
 		"does not catch intervening exceptions",
 		test(async function (this: SinonSandbox) {
 			const authStub = this.stub(support.database, "authenticateHost").resolves();
-			const listStub = this.stub(support.tournamentManager, "getConfirmed").rejects();
+			const listStub = this.stub(support.database, "getConfirmed").rejects();
 			msg.channel.createMessage = this.spy();
 			try {
 				await command.executor(msg, args, support);
@@ -57,7 +57,7 @@ describe("command:dump", function () {
 		"does not catch reply exceptions",
 		test(async function (this: SinonSandbox) {
 			const authStub = this.stub(support.database, "authenticateHost").resolves();
-			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([]);
+			const listStub = this.stub(support.database, "getConfirmed").resolves([]);
 			msg.channel.createMessage = this.stub().rejects();
 			try {
 				await command.executor(msg, args, support);

--- a/test/commands/dump.unit.ts
+++ b/test/commands/dump.unit.ts
@@ -14,7 +14,7 @@ describe("command:dump", function () {
 	it(
 		"provides a dump of all decks",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([
 				{ discordId: "1312", deck: "ydke://!!!", challongeId: 1 },
 				{ discordId: "1314", deck: "ydke://!!!", challongeId: 2 },
@@ -40,7 +40,7 @@ describe("command:dump", function () {
 	it(
 		"does not catch intervening exceptions",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const listStub = this.stub(support.tournamentManager, "getConfirmed").rejects();
 			msg.channel.createMessage = this.spy();
 			try {
@@ -56,7 +56,7 @@ describe("command:dump", function () {
 	it(
 		"does not catch reply exceptions",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([]);
 			msg.channel.createMessage = this.stub().rejects();
 			try {

--- a/test/commands/finish.unit.ts
+++ b/test/commands/finish.unit.ts
@@ -9,7 +9,7 @@ describe("command:finish", function () {
 	it(
 		"finishes the tournament",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const finishStub = this.stub(support.tournamentManager, "finishTournament").resolves();
 			msg.channel.createMessage = this.spy();
 			await command.executor(msg, args, support);
@@ -23,7 +23,7 @@ describe("command:finish", function () {
 	it(
 		"does not catch finishTournament exceptions",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const finishStub = this.stub(support.tournamentManager, "finishTournament").rejects();
 			msg.channel.createMessage = this.spy();
 			try {
@@ -39,7 +39,7 @@ describe("command:finish", function () {
 	it(
 		"does not catch reply exceptions",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const finishStub = this.stub(support.tournamentManager, "finishTournament").resolves();
 			msg.channel.createMessage = this.stub().rejects();
 			try {

--- a/test/commands/pie.unit.ts
+++ b/test/commands/pie.unit.ts
@@ -14,7 +14,7 @@ describe("command:pie", function () {
 	it(
 		"provides a dump of all themes",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([
 				{ discordId: "1312", deck: "ydke://!!!", challongeId: 1 },
 				{ discordId: "1314", deck: "ydke://!!!", challongeId: 2 },
@@ -36,7 +36,7 @@ describe("command:pie", function () {
 	it(
 		"does not catch intervening exceptions",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const listStub = this.stub(support.tournamentManager, "getConfirmed").rejects();
 			msg.channel.createMessage = this.spy();
 			try {
@@ -52,7 +52,7 @@ describe("command:pie", function () {
 	it(
 		"does not catch reply exceptions",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([]);
 			msg.channel.createMessage = this.stub().rejects();
 			try {

--- a/test/commands/pie.unit.ts
+++ b/test/commands/pie.unit.ts
@@ -15,7 +15,7 @@ describe("command:pie", function () {
 		"provides a dump of all themes",
 		test(async function (this: SinonSandbox) {
 			const authStub = this.stub(support.database, "authenticateHost").resolves();
-			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([
+			const listStub = this.stub(support.database, "getConfirmed").resolves([
 				{ discordId: "1312", deck: "ydke://!!!", challongeId: 1 },
 				{ discordId: "1314", deck: "ydke://!!!", challongeId: 2 },
 				{ discordId: "1234", deck: "ydke://!!!", challongeId: 3 }
@@ -37,7 +37,7 @@ describe("command:pie", function () {
 		"does not catch intervening exceptions",
 		test(async function (this: SinonSandbox) {
 			const authStub = this.stub(support.database, "authenticateHost").resolves();
-			const listStub = this.stub(support.tournamentManager, "getConfirmed").rejects();
+			const listStub = this.stub(support.database, "getConfirmed").rejects();
 			msg.channel.createMessage = this.spy();
 			try {
 				await command.executor(msg, args, support);
@@ -53,7 +53,7 @@ describe("command:pie", function () {
 		"does not catch reply exceptions",
 		test(async function (this: SinonSandbox) {
 			const authStub = this.stub(support.database, "authenticateHost").resolves();
-			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([]);
+			const listStub = this.stub(support.database, "getConfirmed").resolves([]);
 			msg.channel.createMessage = this.stub().rejects();
 			try {
 				await command.executor(msg, args, support);

--- a/test/commands/players.unit.ts
+++ b/test/commands/players.unit.ts
@@ -15,7 +15,7 @@ describe("command:players", function () {
 		"provides a dump of all players",
 		test(async function (this: SinonSandbox) {
 			const authStub = this.stub(support.database, "authenticateHost").resolves();
-			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([
+			const listStub = this.stub(support.database, "getConfirmed").resolves([
 				{ discordId: "1312", deck: "ydke://!!!", challongeId: 1 },
 				{ discordId: "1314", deck: "ydke://!!!", challongeId: 2 },
 				{ discordId: "1234", deck: "ydke://!!!", challongeId: 3 }
@@ -37,7 +37,7 @@ describe("command:players", function () {
 		"does not catch intervening exceptions",
 		test(async function (this: SinonSandbox) {
 			const authStub = this.stub(support.database, "authenticateHost").resolves();
-			const listStub = this.stub(support.tournamentManager, "getConfirmed").rejects();
+			const listStub = this.stub(support.database, "getConfirmed").rejects();
 			msg.channel.createMessage = this.spy();
 			try {
 				await command.executor(msg, args, support);
@@ -53,7 +53,7 @@ describe("command:players", function () {
 		"does not catch reply exceptions",
 		test(async function (this: SinonSandbox) {
 			const authStub = this.stub(support.database, "authenticateHost").resolves();
-			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([]);
+			const listStub = this.stub(support.database, "getConfirmed").resolves([]);
 			msg.channel.createMessage = this.stub().rejects();
 			try {
 				await command.executor(msg, args, support);

--- a/test/commands/players.unit.ts
+++ b/test/commands/players.unit.ts
@@ -14,7 +14,7 @@ describe("command:players", function () {
 	it(
 		"provides a dump of all players",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([
 				{ discordId: "1312", deck: "ydke://!!!", challongeId: 1 },
 				{ discordId: "1314", deck: "ydke://!!!", challongeId: 2 },
@@ -36,7 +36,7 @@ describe("command:players", function () {
 	it(
 		"does not catch intervening exceptions",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const listStub = this.stub(support.tournamentManager, "getConfirmed").rejects();
 			msg.channel.createMessage = this.spy();
 			try {
@@ -52,7 +52,7 @@ describe("command:players", function () {
 	it(
 		"does not catch reply exceptions",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.tournamentManager, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves();
 			const listStub = this.stub(support.tournamentManager, "getConfirmed").resolves([]);
 			msg.channel.createMessage = this.stub().rejects();
 			try {

--- a/test/commands/removebye.unit.ts
+++ b/test/commands/removebye.unit.ts
@@ -17,7 +17,7 @@ describe("command:removebye", function () {
 		test(async function (this: SinonSandbox) {
 			msg.mentions = [new User({ id: "nova" }, mockBotClient)];
 			msg.channel.createMessage = this.spy();
-			this.stub(support.tournamentManager, "removeBye").resolves([]);
+			this.stub(support.database, "removeBye").resolves([]);
 			await command.executor(msg, ["name"], support);
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
 				"Bye removed for Player <@nova> (nova) in Tournament name!\nAll byes: "

--- a/test/commands/update.unit.ts
+++ b/test/commands/update.unit.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
-import sinon from "sinon";
+import sinon, { SinonSandbox } from "sinon";
 import command from "../../src/commands/update";
-import { itRejectsNonHosts, msg, support } from "./common";
+import { itRejectsNonHosts, msg, support, test } from "./common";
 
 describe("command:update", function () {
 	itRejectsNonHosts(support, command, msg, ["name"]);
@@ -12,4 +12,32 @@ describe("command:update", function () {
 			"Tournament `name` updated! It now has the name newName and the given description."
 		);
 	});
+	it(
+		"calls the appropriate functions",
+		test(async function (this: SinonSandbox) {
+			this.stub(support.database, "updateTournament").resolves();
+			this.stub(support.challonge, "updateTournament").resolves();
+			await command.executor(msg, ["name", "newName", "newDesc"], support);
+			expect(support.database.updateTournament).to.have.been.calledOnceWithExactly("name", "newName", "newDesc");
+			expect(support.challonge.updateTournament).to.have.been.calledOnceWithExactly("name", "newName", "newDesc");
+		})
+	);
+	it(
+		"does not update challonge if database throws",
+		test(async function (this: SinonSandbox) {
+			this.stub(support.database, "updateTournament").rejects();
+			this.stub(support.challonge, "updateTournament").resolves();
+			try {
+				await command.executor(msg, ["name", "newName", "newDesc"], support);
+				expect.fail();
+			} catch (e) {
+				expect(support.database.updateTournament).to.have.been.calledOnceWithExactly(
+					"name",
+					"newName",
+					"newDesc"
+				);
+				expect(support.challonge.updateTournament).to.have.not.been.called;
+			}
+		})
+	);
 });

--- a/test/mocks/database.ts
+++ b/test/mocks/database.ts
@@ -302,6 +302,9 @@ export class DatabaseWrapperMock {
 	dropFromAll(): ReturnType<DatabaseWrapperPostgres["dropFromAll"]> {
 		throw new Error("Not implemented");
 	}
+	async getConfirmed(): Promise<DatabasePlayer[]> {
+		return [];
+	}
 	getConfirmedPlayer(): Promise<DatabasePlayer> {
 		throw new Error("Not implemented");
 	}

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -150,9 +150,6 @@ describe("Misc commands", function () {
 			"Player <@player1> (player1) has been forcefully dropped from Tournament Tournament 1 (tourn1)."
 		);
 	});
-	it("Sync tournament", async function () {
-		await expect(tournament.syncTournament("tourn1")).to.not.be.rejected;
-	});
 	it.skip("Generate pie chart", async function () {
 		// const file = await tournament.generatePieChart("tourn1");
 		// expect(file.filename).to.equal("Tournament 1 Pie.csv");

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -67,12 +67,6 @@ describe("Tournament creation commands", async function () {
 		const [id] = await tournament.createTournament("testUser", "testServer", "create1", "desc");
 		expect(id).to.equal("create10");
 	});
-	it("Add host", async function () {
-		await expect(tournament.addHost("name", "testUser")).to.not.be.rejected;
-	});
-	it("Remove host", async function () {
-		await expect(tournament.removeHost("name", "testUser")).to.not.be.rejected;
-	});
 });
 
 describe("Tournament flow commands", function () {

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -70,12 +70,6 @@ describe("Tournament creation commands", async function () {
 	it("Update tournament", async function () {
 		await expect(tournament.updateTournament("name", "newName", "newDesc")).to.not.be.rejected;
 	});
-	it("Add announcement channel", async function () {
-		await expect(tournament.addAnnouncementChannel("create", "testChannel", "public")).to.not.be.rejected;
-	});
-	it("Remove announcement channel", async function () {
-		await expect(tournament.removeAnnouncementChannel("name", "testChannel", "public")).to.not.be.rejected;
-	});
 	it("Add host", async function () {
 		await expect(tournament.addHost("name", "testUser")).to.not.be.rejected;
 	});

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -67,9 +67,6 @@ describe("Tournament creation commands", async function () {
 		const [id] = await tournament.createTournament("testUser", "testServer", "create1", "desc");
 		expect(id).to.equal("create10");
 	});
-	it("Update tournament", async function () {
-		await expect(tournament.updateTournament("name", "newName", "newDesc")).to.not.be.rejected;
-	});
 	it("Add host", async function () {
 		await expect(tournament.addHost("name", "testUser")).to.not.be.rejected;
 	});

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -415,10 +415,4 @@ describe("Misc functions", function () {
 			})
 		).to.not.be.rejected;
 	});
-	it("Authenticate host", async function () {
-		await expect(tournament.authenticateHost("tourn1", "testUser")).to.not.be.rejected;
-	});
-	it("Authenticate player", async function () {
-		await expect(tournament.authenticatePlayer("tourn1", "player1")).to.not.be.rejected;
-	});
 });

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -132,13 +132,6 @@ describe("Tournament flow commands", function () {
 });
 
 describe("Misc commands", function () {
-	it("List tournaments", async function () {
-		const list = await tournament.listTournaments();
-		const expectedList =
-			"ID: tourn1|Name: Tournament 1|Status: preparing|Players: 4\nID: tourn2|Name: Tournament 2|Status: in progress|Players: 3";
-		const testList = list.slice(0, expectedList.length);
-		expect(testList).to.equal(expectedList);
-	});
 	it.skip("List players", async function () {
 		// const file = await tournament.listPlayers("tourn1");
 		// expect(file.filename).to.equal("Tournament 1.csv");


### PR DESCRIPTION
## Description

This should improve the structure of the code, removing unnecessary indirection and allowing more nuanced testing. The following methods from `TournamentManager` have been integrated into the relevant commands: 
- `authenticateHost`
- `authenticatePlayer`
- `listTournaments`
- `updateTournament`
- `addAnnouncementChannel`
- `removeAnnouncementChannel`
- `addHost`
- `removeHost`
- `syncTournament`
- `registerBye`
- `removeBye`

Additionally, `getConfirmed` has been moved from `TournamentManager` to `DatabaseWrapperPostgres` and refactored appropriately. Most other methods have not yet been integrated due to their complexity. `cleanRegistration` has not been integrated because it is not command functionality. `getPlayerDeck` is relatively simple, but has not been integrated because it calls a function that is not available in command support. To make it so, Deck-related structure may need a slight refactor.
## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).