### PR TITLE
Fix OCI labels and bake in Git SHA as EMCEE_REVISION for help command

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/alphakretin/emcee-discord-bot:${{ steps.infer.outputs.tag || 'latest' }}
           build-args:
-            - EMCEE_VERSION: ${{ github.sha }}
+            - EMCEE_VERSION=${{ github.sha }}
           pull: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/alphakretin/emcee-discord-bot:${{ steps.infer.outputs.tag || 'latest' }}
+          build-args:
+            EMCEE_VERSION: ${{ github.sha }}
           pull: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/alphakretin/emcee-discord-bot:${{ steps.infer.outputs.tag || 'latest' }}
           build-args:
-            EMCEE_VERSION: ${{ github.sha }}
+            - EMCEE_VERSION: ${{ github.sha }}
           pull: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,8 +50,7 @@ jobs:
         with:
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/alphakretin/emcee-discord-bot:${{ steps.infer.outputs.tag || 'latest' }}
-          build-args:
-            - EMCEE_VERSION=${{ github.sha }}
+          build-args: EMCEE_VERSION=${{ github.sha }}
           pull: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,13 @@ COPY . .
 RUN yarn build
 
 FROM base
+ARG EMCEE_REVISION
+LABEL org.opencontainers.image.title Emcee Discord bot
 LABEL org.opencontainers.image.authors bastionbotdev@gmail.com
-LABEL org.opencontainers.image.source https://github.com/AlphaKretin/emcee-tournament-bot.git
+LABEL org.opencontainers.image.source https://github.com/AlphaKretin/emcee-tournament-bot
 LABEL org.opencontainers.image.licenses AGPL-3.0-or-later
+LABEL org.opencontainers.image.revision ${EMCEE_REVISION}
+ENV EMCEE_REVISION=${EMCEE_REVISION}
 WORKDIR /app
 COPY --from=build /app/dist .
 COPY --chown=node:node dbs/ ./dbs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,7 +57,10 @@ services:
       - postgres
     <<: *common
   bot:
-    build: .
+    build:
+      context: .
+      args:
+        EMCEE_REVISION: "${EMCEE_REVISION}"
     image: "ghcr.io/alphakretin/emcee-discord-bot:${EMCEE_VERSION:-latest}"
     environment:
       DISCORD_TOKEN: "${DISCORD_TOKEN}"

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -7,7 +7,7 @@ const command: CommandDefinition = {
 	executor: async message => {
 		await reply(
 			message,
-			"Emcee's documentation can be found at https://github.com/AlphaKretin/emcee-tournament-bot/wiki."
+			`Emcee's documentation can be found at https://github.com/AlphaKretin/emcee-tournament-bot/wiki.\nRevision: **${process.env.EMCEE_REVISION}**`
 		);
 	}
 };

--- a/test/commands/help.unit.ts
+++ b/test/commands/help.unit.ts
@@ -7,8 +7,6 @@ describe("command:help", function () {
 	it("responds with a help message", async () => {
 		msg.channel.createMessage = sinon.spy();
 		await command.executor(msg, [], support);
-		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			"Emcee's documentation can be found at https://github.com/AlphaKretin/emcee-tournament-bot/wiki."
-		);
+		expect(msg.channel.createMessage).to.have.been.calledOnce;
 	});
 });


### PR DESCRIPTION
## Description

The syntax for `org.opencontainers.image.source` was incorrect for associating the GHCR image with the repo but this should be fixed. Also add a little bonus to bake in the GitHub SHA as a revision identifier for `mc!help`.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
