### PR TITLE
Add utility script to clean up old challonge tournaments

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"test": "nyc mocha --config test/.mocharc.yml test/*.ts test/**/*.unit.ts",
 		"cover": "nyc report",
 		"lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-		"build": "tsc"
+		"build": "tsc",
+		"clean": "ts-node util/clean.ts"
 	},
 	"author": "Luna Brand",
 	"contributors": [

--- a/util/clean.ts
+++ b/util/clean.ts
@@ -1,0 +1,31 @@
+import fetch from "node-fetch";
+import dotenv from "dotenv";
+dotenv.config();
+
+const user = process.env.CHALLONGE_USERNAME;
+const token = process.env.CHALLONGE_TOKEN;
+
+function url(id: string): string {
+	return `https://${user}:${token}@api.challonge.com/v1/tournaments/${id}.json`;
+}
+
+async function destroy(id: string): Promise<void> {
+	const response = await fetch(url(id), {
+		method: "DELETE",
+		headers: { "Content-Type": "application/json" }
+	});
+	if (!response.ok) {
+		throw new Error(response.statusText);
+	}
+}
+
+// list of tournament ids to delete, fill out before running
+const list: string[] = [];
+
+async function go(): Promise<void> {
+	for (const id of list) {
+		await destroy(id);
+	}
+}
+
+go().catch(console.error);

--- a/util/clean.ts
+++ b/util/clean.ts
@@ -19,10 +19,8 @@ async function destroy(id: string): Promise<void> {
 	}
 }
 
-// list of tournament ids to delete, fill out before running
-const list: string[] = [];
-
 async function go(): Promise<void> {
+	const list = process.argv.slice(2); // first two args are "~/ts-node" and "~/clean.ts"
 	for (const id of list) {
 		await destroy(id);
 	}


### PR DESCRIPTION
## Description

Use by running `yarn clean id [id id ...]`. I feel like this PR should have some kind of tag to indicate that it doesn't change anything about Emcee directly, but we don't have such a tag set up yet.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
