### PR TITLE
Separate first round from mc!start

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### New Features
 - Emcee reports its current version in the `mc!help` command.
+- Starting the timer and sending the pairing for round 1 no longer happens automatically after `mc!start` and requires a manual call of `mc!round`. This is to allow for intervention if something goes wrong with the start process, before telling players to play.
 - Creating the Top Cut for a tournament is a separate `mc!topcut` command that can be called on a tournament after `mc!finish` is used. This allows taking a break between the end of Swiss and the start of Top Cut.
 - New `mc!tie` command changes all open matches in the current round to a tie. This is useful when a number of matches are outstanding at the end of a round or tournament.
 - A custom timer length can now be specified for `mc!round` and `mc!start` (for the first round).

--- a/guides/open.template.md
+++ b/guides/open.template.md
@@ -24,12 +24,7 @@ You can download a CSV file of how many decks have each archetype.
 ```
 mc!pie {}```
 **Start tournament**
-This will start the first round of play.
-Further details will be sent to private channels.
+This will commence the tournament on challonge, assigning round 1 byes and allowing play to begin.
+Further details will be sent to private channels, including how to start the timer and send out matchups.
 ```
-mc!start {}|TIMER|skip```
-Both the timer and skip parameters are optional.
-The round timer defaults to 50 minutes and must be of the form `mm` or `hh:mm`.
-This only applies to round 1 and an explicit zero timer results in no timer.
-The skip parameter must come after the timer parameter if provided and be exactly `skip`.
-It skips sending pairings in DMs.
+mc!start {}```

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,6 +1,5 @@
 import { CommandDefinition } from "../Command";
 import { TournamentStatus } from "../database/interface";
-import { advanceRoundDiscord, parseTime } from "../round";
 import { reply } from "../util/discord";
 import { UserError } from "../util/errors";
 import { getLogger } from "../util/logger";
@@ -18,8 +17,6 @@ const command: CommandDefinition = {
 		// id|timer|skip
 		// 50 is the assumed default timer for live tournaments
 		const [id] = args;
-		const skip = args[1] === "skip" || args[2] === "skip";
-		const timer = (args.length === 2 && !skip) || args.length > 2 ? parseTime(args[1]) : 50;
 		const tournament = await support.database.authenticateHost(id, msg.author.id, TournamentStatus.PREPARING);
 		function log(event: string, payload?: Record<string, unknown>): string {
 			return JSON.stringify({
@@ -32,7 +29,7 @@ const command: CommandDefinition = {
 				...payload
 			});
 		}
-		logger.verbose(log("attempt", { timer, skip }));
+		logger.verbose(log("attempt"));
 		if (tournament.players.length < 2) {
 			throw new UserError("Cannot start a tournament without at least 2 confirmed participants!");
 		}
@@ -58,7 +55,10 @@ const command: CommandDefinition = {
 			logger.info(log("challonge"));
 			await support.database.startTournament(id);
 			logger.verbose(log("database"));
-			await reply(msg, `**${tournament.name}** commenced on Challonge! Now sending out pairings for round 1.`);
+			await reply(
+				msg,
+				`**${tournament.name}** commenced on Challonge! Use \`mc!round ${id}\` to send out pairings and start the timer for round 1.`
+			);
 		} catch (err) {
 			logger.error(err);
 			await reply(msg, `Something went wrong in preflight for **${tournament.name}**. Please try again later.`);
@@ -74,15 +74,9 @@ const command: CommandDefinition = {
 			await support.discord.sendMessage(channel, support.templater.format("start", id)).catch(logger.error);
 		}
 		logger.verbose(log("private"));
-		await advanceRoundDiscord(support, tournament, timer, skip);
-		logger.verbose(log("round"));
 		// drop dummy players once the tournament has started to give players with byes the win
 		await support.challonge.dropByes(id, tournament.byes.length);
-		logger.info(log("drop byes"));
-		await reply(
-			msg,
-			`Pairings sent out for **${tournament.name}**. Please check the private channels for any failed DMs.`
-		);
+		logger.info(log("success"));
 	}
 };
 


### PR DESCRIPTION
## Description

Allows for manual corrections in case of preflight error, without alerting players to the false start of a round.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
