### PR TITLE
Add a hint for deck resubmission policy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,8 @@
 ## HEAD
 
 ### New Features
-- `mc!topcut` supports arbitrary size top cuts instead of specifically 8. The size is now required.
+- Deck resubmission policy is explicitly stated on submission. This was a frequently-asked question. (#230)
+- `mc!topcut` supports arbitrary size top cuts instead of specifically 8. The size is now required. (#231)
 
 ## 2021-03-28 ([Chalislime Monthly March 2021](https://challonge.com/csmmar21))
 

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -203,7 +203,7 @@ async function verifyDeckAndConfirmPending(
 	try {
 		await reply(
 			msg,
-			`You have successfully signed up for **${tournament.name}**! Your deck is below to double-check.`
+			`You have successfully signed up for **${tournament.name}**! Your deck is below to double-check. You may resubmit at any time before the tournament starts.`
 		);
 		await reply(msg, ...formattedDeckMessage);
 	} catch (error) {
@@ -254,7 +254,7 @@ async function verifyDeckAndUpdateConfirmed(
 	try {
 		await reply(
 			msg,
-			`You have successfully changed your deck for **${tournament.name}**! Your deck is below to double-check.`
+			`You have successfully changed your deck for **${tournament.name}**! Your deck is below to double-check. You may resubmit at any time before the tournament starts.`
 		);
 		await reply(msg, ...formattedDeckMessage);
 	} catch (error) {

--- a/test/events/messageCreate.unit.ts
+++ b/test/events/messageCreate.unit.ts
@@ -70,7 +70,7 @@ describe("Direct message submissions", function () {
 			);
 			expect(mockBotClient.createMessage).to.have.been.calledWith("channel2", {}, { name: "mock", file: "mock" });
 			expect(sampleMessage.channel.createMessage).to.have.been.calledWith(
-				"You have successfully signed up for **Tournament 1**! Your deck is below to double-check."
+				"You have successfully signed up for **Tournament 1**! Your deck is below to double-check. You may resubmit at any time before the tournament starts."
 			);
 			expect(sampleMessage.channel.createMessage).to.have.been.calledWith({}, { name: "mock", file: "mock" });
 		})
@@ -161,7 +161,7 @@ describe("Direct message submissions", function () {
 			);
 			expect(mockBotClient.createMessage).to.have.been.calledWith("channel2", {}, { name: "mock", file: "mock" });
 			expect(sampleMessage.channel.createMessage).to.have.been.calledWith(
-				"You have successfully changed your deck for **Tournament 1**! Your deck is below to double-check."
+				"You have successfully changed your deck for **Tournament 1**! Your deck is below to double-check. You may resubmit at any time before the tournament starts."
 			);
 			expect(sampleMessage.channel.createMessage).to.have.been.calledWith({}, { name: "mock", file: "mock" });
 		})


### PR DESCRIPTION
## Description

This is a frequently asked question.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
