### PR TITLE
Support arbitrary-size top cuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supports YGOPro deck files (.ydk) and `ydke://` URLs from [Project Ignis: EDOPro
 Emcee automates the tedious tasks of the sign-up process, deck checks, and tracking match scores for tournament hosts.
 This frees up hosts to focus on the overall flow of the tournament and any disputes instead of a lot of repetitive work.
 It currently supports hosting Swiss tournaments of up to 256 participants (a limitation of Challonge's [standard tier](https://challonge.com/pricing))
-with an 8-member single-elimination top cut (to be made configurable).
+with an optional single-elimination top cut of configurable size.
 
 Currently in use in alpha (no pun intended) for the [Chalislime Monthly](https://youtu.be/iehvqngGxs0) tournament series.
 Thanks to [Joseph Rothschild](https://www.youtube.com/c/MBTYuGiOh) aka [MBT](https://www.twitch.tv/mbtyugioh) for

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## HEAD
+
+### New Features
+- `mc!topcut` supports arbitrary size top cuts instead of specifically 8. The size is now required.
+
 ## 2021-03-28 ([Chalislime Monthly March 2021](https://challonge.com/csmmar21))
 
 ### New Features

--- a/docs/usage-organiser.md
+++ b/docs/usage-organiser.md
@@ -227,12 +227,14 @@ the participant role for this tournament is deleted.
 
 ### Start top cut tournament
 ```
-mc!topcut id
+mc!topcut id|size
 ```
 **Caller permission level**: host for the tournament identified by _id_
 
-If the tournament is finished and has more than eight participants, a new single-elimination
-top cut tournament is started on Challonge with the top eight participants. The same
+_size_ should be a positive integer that makes sense for the tournament.
+
+If the tournament is finished and has at least _size_ participants, a new single-elimination
+top cut tournament is started on Challonge with the top _size_ participants. The same
 hosts, decks, and announcement channels are retained, and a new participant role
 is granted to these users.
 

--- a/guides/start.template.md
+++ b/guides/start.template.md
@@ -31,5 +31,5 @@ If you need to stop early, you can cancel.
 mc!cancel {}```
 **Top cut**
 ```
-mc!topcut {}```
-Fires off top cut for a completed tournament.
+mc!topcut {}|size```
+Fires off a top cut with the given size for a completed tournament.

--- a/src/commands/topcut.ts
+++ b/src/commands/topcut.ts
@@ -7,9 +7,13 @@ const logger = getLogger("command:topcut");
 
 const command: CommandDefinition = {
 	name: "topcut",
-	requiredArgs: ["id"],
+	requiredArgs: ["id", "size"],
 	executor: async (msg, args, support) => {
-		const [id] = args;
+		const [id, sizeRaw] = args;
+		const size = parseInt(sizeRaw, 10);
+		if (isNaN(size) || size < 2) {
+			await reply(msg, `Bad top cut size of ${sizeRaw}.`);
+		}
 		const tournament = await support.database.authenticateHost(id, msg.author.id, TournamentStatus.COMPLETE);
 		logger.verbose(
 			JSON.stringify({
@@ -19,14 +23,15 @@ const command: CommandDefinition = {
 				tournament: id,
 				command: "topcut",
 				pool: tournament.players.length,
+				size,
 				event: "attempt"
 			})
 		);
-		if (tournament.players.length <= 8) {
+		if (tournament.players.length < size) {
 			await reply(msg, `**${tournament.name}** only has ${tournament.players.length} participants!`);
 			return;
 		}
-		const top = await support.challonge.getTopCut(id, 8);
+		const top = await support.challonge.getTopCut(id, size);
 		const [newId] = await support.tournamentManager.createTournament(
 			tournament.hosts[0], // tournament cannot have 0 hosts by addition on creation and guard on removal
 			tournament.server,

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -148,7 +148,7 @@ export class WebsiteInterface {
 		return tournament;
 	}
 
-	public async getTopCut(tournamentId: string, cut = 8): Promise<WebsitePlayer[]> {
+	public async getTopCut(tournamentId: string, cut: number): Promise<WebsitePlayer[]> {
 		const players = await this.api.getPlayers(tournamentId);
 		return players.sort((p1, p2) => p1.rank - p2.rank).slice(0, cut); // descending order
 	}


### PR DESCRIPTION
## Description

The size of a top cut is now a required parameter. No checks are made if the value makes sense for a single-elimination bracket beyond being at least 2.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
