### PR TITLE
Restrict tournament host commands to the owning server

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 - Fix a typo in `mc!forcedrop` success message where it indicated confirmed participants were pending. (#236)
 - Fix a bug with users with IDs starting with 9 not receiving pairing direct messages. (#237)
+- Host commands can no longer be run in direct messages or other servers
 
 ## 2021-03-28 ([Chalislime Monthly March 2021](https://challonge.com/csmmar21))
 

--- a/docs/usage-organiser.md
+++ b/docs/usage-organiser.md
@@ -7,6 +7,10 @@ these are separated from each other by a pipe `|`, and from the command name by 
 following, any words that are separated by `|` refer to the _name_ of the parameter, and you should
 replace them with an appropriate value when you use these commands!
 
+All host commands are scoped to the current server and do not work in direct messages.
+Tournaments can only be managed from the server that they were created in;
+they cannot be accessed from other servers.
+
 ## Index
 
 <!--

--- a/src/commands/addbye.ts
+++ b/src/commands/addbye.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const player = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/addchannel.ts
+++ b/src/commands/addchannel.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id, baseType] = args; // 1 optional and thus potentially undefined
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const type = baseType?.toLowerCase() === "private" ? "private" : "public";
 		const channelId = msg.channel.id;
 		logger.verbose(

--- a/src/commands/addhost.ts
+++ b/src/commands/addhost.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const newHost = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/cancel.ts
+++ b/src/commands/cancel.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// This executor's logic is now surprisingly similar to finish
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/deck.ts
+++ b/src/commands/deck.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const player = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/dump.ts
+++ b/src/commands/dump.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/finish.ts
+++ b/src/commands/finish.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/forcedrop.ts
+++ b/src/commands/forcedrop.ts
@@ -11,7 +11,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id", "who"],
 	executor: async (msg, args, support) => {
 		const [id, who] = args;
-		const tournament = await support.database.authenticateHost(id, msg.author.id);
+		const tournament = await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const player = who.startsWith("<@!") && who.endsWith(">") ? who.slice(3, -1) : who;
 		function log(payload: Record<string, unknown>): void {
 			logger.verbose(

--- a/src/commands/forcescore.ts
+++ b/src/commands/forcescore.ts
@@ -29,7 +29,12 @@ const command: CommandDefinition = {
 			throw new UserError("Must provide score in format `#-#` e.g. `2-1`.");
 		}
 		// Check command syntax first to avoid a database round trip
-		const tournament = await support.database.authenticateHost(id, msg.author.id, TournamentStatus.IPR);
+		const tournament = await support.database.authenticateHost(
+			id,
+			msg.author.id,
+			msg.guildID,
+			TournamentStatus.IPR
+		);
 		try {
 			// eslint-disable-next-line no-var
 			var { challongeId } = await support.database.getConfirmedPlayer(player, id);

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/pie.ts
+++ b/src/commands/pie.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/players.ts
+++ b/src/commands/players.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/removebye.ts
+++ b/src/commands/removebye.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// Mirror of addbye
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const player = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/removechannel.ts
+++ b/src/commands/removechannel.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// Mirror of addchannel
 		const [id, baseType] = args; // 1 optional and thus potentially undefined
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const type = baseType?.toLowerCase() === "private" ? "private" : "public";
 		const channelId = msg.channel.id;
 		logger.verbose(

--- a/src/commands/removehost.ts
+++ b/src/commands/removehost.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// Mirror of addhost
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const newHost = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/round.ts
+++ b/src/commands/round.ts
@@ -19,7 +19,12 @@ const command: CommandDefinition = {
 		const [id] = args;
 		const skip = args[1] === "skip" || args[2] === "skip";
 		const timer = (args.length === 2 && !skip) || args.length > 2 ? parseTime(args[1]) : 50;
-		const tournament = await support.database.authenticateHost(id, msg.author.id, TournamentStatus.IPR);
+		const tournament = await support.database.authenticateHost(
+			id,
+			msg.author.id,
+			msg.guildID,
+			TournamentStatus.IPR
+		);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -17,7 +17,12 @@ const command: CommandDefinition = {
 		// id|timer|skip
 		// 50 is the assumed default timer for live tournaments
 		const [id] = args;
-		const tournament = await support.database.authenticateHost(id, msg.author.id, TournamentStatus.PREPARING);
+		const tournament = await support.database.authenticateHost(
+			id,
+			msg.author.id,
+			msg.guildID,
+			TournamentStatus.PREPARING
+		);
 		function log(event: string, payload?: Record<string, unknown>): string {
 			return JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/tie.ts
+++ b/src/commands/tie.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id, TournamentStatus.IPR);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID, TournamentStatus.IPR);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/topcut.ts
+++ b/src/commands/topcut.ts
@@ -10,7 +10,12 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		const tournament = await support.database.authenticateHost(id, msg.author.id, TournamentStatus.COMPLETE);
+		const tournament = await support.database.authenticateHost(
+			id,
+			msg.author.id,
+			msg.guildID,
+			TournamentStatus.COMPLETE
+		);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id", "name", "description"],
 	executor: async (msg, args, support) => {
 		const [id, name, desc] = args;
-		await support.database.authenticateHost(id, msg.author.id);
+		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -84,9 +84,13 @@ export class DatabaseWrapperPostgres {
 	public async authenticateHost(
 		tournamentId: string,
 		hostId: string,
+		serverId?: string,
 		assertStatus?: TournamentStatus
 	): Promise<DatabaseTournament> {
 		const tournament = await this.findTournament(tournamentId);
+		if (tournament.owningDiscordServer !== serverId) {
+			throw new TournamentNotFoundError(tournamentId);
+		}
 		if (!tournament.hosts.includes(hostId)) {
 			throw new UnauthorisedHostError(hostId, tournamentId);
 		}


### PR DESCRIPTION
## Description

Fixes a flaw where per-server isolation isn't respected for executing host commands. Host commands can also no longer be run in direct messages. The only Emcee functions available in direct messages are the sign-up process, help commands, and participant commands. Now that I'm writing this, it may be worth it to restrict participant commands to the same server and direct messages as well.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
