### PR TITLE
Update removehost to also not require explicit mentions, like forcedrop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### New Features
 - `mc!topcut` supports arbitrary size top cuts instead of specifically 8. The size is now required.
+- `mc!removehost` supports IDs to allow removing hosts who leave the server. (#234)
 
 ## 2021-03-28 ([Chalislime Monthly March 2021](https://challonge.com/csmmar21))
 

--- a/docs/usage-organiser.md
+++ b/docs/usage-organiser.md
@@ -83,10 +83,13 @@ mc!removehost id|@user
 ```
 **Caller permission level**: host for the tournament identified by _id_
 
-`@user` must be a valid Discord mention of a user that pings them.
+`@user` can be a Discord mention, though it does not have to ping, or the user's ID.
 
 The user is deauthorised as a host for the specified tournament, losing all corresponding permissions.
 You cannot remove yourself if you are the only host; there must always be one host to manage the tournament.
+
+If a host leaves the tournament server, they are not automatically removed and will regain
+powers for their tournaments if they return.
 
 ### Add announcement channel
 ```
@@ -293,6 +296,9 @@ are unconfirmed. If the tournament is in progress, the match is automatically fo
 the opponent `2-0` unless they have also dropped, in which case it is amended to a `0-0` draw.
 
 This is irreversible. The participant is informed of the removal via direct message.
+
+If a confirmed participant leaves the server for a tournament while Emcee is online,
+they should be automatically dropped from the tournament by Emcee.
 
 ### Show participant deck
 ```

--- a/src/commands/removehost.ts
+++ b/src/commands/removehost.ts
@@ -1,17 +1,17 @@
 import { CommandDefinition } from "../Command";
-import { firstMentionOrFail, reply } from "../util/discord";
+import { reply } from "../util/discord";
 import { getLogger } from "../util/logger";
 
 const logger = getLogger("command:removehost");
 
 const command: CommandDefinition = {
 	name: "removehost",
-	requiredArgs: ["id"],
+	requiredArgs: ["id", "who"],
 	executor: async (msg, args, support) => {
 		// Mirror of addhost
-		const [id] = args;
+		const [id, who] = args;
 		await support.database.authenticateHost(id, msg.author.id);
-		const newHost = firstMentionOrFail(msg);
+		const newHost = who.startsWith("<@!") && who.endsWith(">") ? who.slice(3, -1) : who;
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/test/commands/removehost.unit.ts
+++ b/test/commands/removehost.unit.ts
@@ -6,18 +6,20 @@ import { itRejectsNonHosts, mockBotClient, msg, support } from "./common";
 
 describe("command:removehost", function () {
 	itRejectsNonHosts(support, command, msg, ["name"]);
-	it("requires a mentioned user", async () => {
+	it("supports mentioned users", async () => {
 		msg.mentions = [];
 		msg.channel.createMessage = sinon.spy();
-		expect(command.executor(msg, ["name"], support)).to.be.rejectedWith("Message does not mention a user!");
-		expect(msg.channel.createMessage).to.not.have.been.called;
+		await command.executor(msg, ["name", "<@!snowflake>"], support);
+		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
+			"<@snowflake> removed as a host for Tournament name!"
+		);
 	});
-	it("removes the mentioned user", async () => {
+	it("supports user ids", async () => {
 		msg.mentions = [new User({ id: "nova" }, mockBotClient)];
 		msg.channel.createMessage = sinon.spy();
-		await command.executor(msg, ["name"], support);
+		await command.executor(msg, ["name", "raw-snowflake"], support);
 		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			"<@nova> removed as a host for Tournament name!"
+			"<@raw-snowflake> removed as a host for Tournament name!"
 		);
 	});
 });


### PR DESCRIPTION
## Description

Allows removing hosts who have left the server for some reason.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
