### PR TITLE
Fix certain users not receiving pairing DMs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 - Fix a typo in `mc!forcedrop` success message where it indicated confirmed participants were pending. (#236)
+- Fix a bug with users with IDs starting with 9 not receiving pairing direct messages. (#237)
 
 ## 2021-03-28 ([Chalislime Monthly March 2021](https://challonge.com/csmmar21))
 

--- a/src/round.ts
+++ b/src/round.ts
@@ -131,7 +131,7 @@ async function getPlayers(challonge: WebsiteInterface, tournamentId: string): Pr
 }
 
 function notSnowflake(userId: string): boolean {
-	return !userId.length || userId[0] <= "0" || userId[0] >= "9";
+	return !userId.length || userId[0] < "0" || userId[0] > "9";
 }
 
 async function getRealUsername(discord: DiscordInterface, userId: string): Promise<string | null> {
@@ -158,7 +158,7 @@ async function sendPairing(
 				? `${intro} Your opponent is <@${opponentId}> (${opponentName}). Make sure to report your score after the match is over!`
 				: `${intro} I couldn't find your opponent. If you don't think you should have a bye for this round, please check the pairings.`
 		);
-	} catch {
+	} catch (err) {
 		await reportFailure(discord, tournament, receiverId, opponentId);
 	}
 }


### PR DESCRIPTION
## Description

notSnowflake was too strict and rejected all snowflakes starting with 9

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
