### PR TITLE
Block post-completion tournament mutations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 - Fix a bug with users with IDs starting with 9 not receiving pairing direct messages. (#237)
 - Host commands can no longer be run in direct messages or other servers. (#223)
 - Participant commands can only be run in direct messages or the same server. (#238)
+- Tournaments can no longer be modified or dropped from after they finish. (#248)
 
 ## 2021-03-28 ([Chalislime Monthly March 2021](https://challonge.com/csmmar21))
 

--- a/src/commands/drop.ts
+++ b/src/commands/drop.ts
@@ -34,6 +34,7 @@ const command: CommandDefinition = {
 			return;
 		}
 		if (participant.tournament.status === TournamentStatus.COMPLETE) {
+			log({ event: "already complete" });
 			await reply(msg, `**${participant.tournament.name}** has already concluded!`);
 			return;
 		}

--- a/src/commands/forcedrop.ts
+++ b/src/commands/forcedrop.ts
@@ -1,4 +1,5 @@
 import { CommandDefinition } from "../Command";
+import { TournamentStatus } from "../database/interface";
 import { Participant } from "../database/orm";
 import { dropPlayerChallonge } from "../drop";
 import { reply } from "../util/discord";
@@ -32,6 +33,11 @@ const command: CommandDefinition = {
 		const name = username ? `<@${player}> (${username})` : who;
 		if (!participant) {
 			await reply(msg, `${name} not found in **${tournament.name}**.`);
+			return;
+		}
+		if (participant.tournament.status === TournamentStatus.COMPLETE) {
+			log({ player, event: "already complete" });
+			await reply(msg, `**${participant.tournament.name}** has already concluded!`);
 			return;
 		}
 		if (participant.confirmed) {

--- a/src/commands/removechannel.ts
+++ b/src/commands/removechannel.ts
@@ -1,4 +1,5 @@
 import { CommandDefinition } from "../Command";
+import { TournamentStatus } from "../database/interface";
 import { reply } from "../util/discord";
 import { getLogger } from "../util/logger";
 
@@ -10,7 +11,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// Mirror of addchannel
 		const [id, baseType] = args; // 1 optional and thus potentially undefined
-		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
+		const tournament = await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const type = baseType?.toLowerCase() === "private" ? "private" : "public";
 		const channelId = msg.channel.id;
 		logger.verbose(
@@ -25,6 +26,10 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
+		if (tournament.status === TournamentStatus.COMPLETE) {
+			await reply(msg, `**${tournament.name}** has already concluded!`);
+			return;
+		}
 		await support.database.removeAnnouncementChannel(id, channelId, type);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,4 +1,5 @@
 import { CommandDefinition } from "../Command";
+import { TournamentStatus } from "../database/interface";
 import { reply } from "../util/discord";
 import { getLogger } from "../util/logger";
 
@@ -9,7 +10,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id", "name", "description"],
 	executor: async (msg, args, support) => {
 		const [id, name, desc] = args;
-		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
+		const tournament = await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,
@@ -22,6 +23,22 @@ const command: CommandDefinition = {
 				event: "attempt"
 			})
 		);
+		if (tournament.status === TournamentStatus.COMPLETE) {
+			logger.verbose(
+				JSON.stringify({
+					channel: msg.channel.id,
+					message: msg.id,
+					user: msg.author.id,
+					tournament: id,
+					command: "update",
+					name,
+					desc,
+					event: "already complete"
+				})
+			);
+			await reply(msg, `**${tournament.name}** has already concluded!`);
+			return;
+		}
 		// Update DB first because it performs an important check that might throw
 		await support.database.updateTournament(id, name, desc);
 		await support.challonge.updateTournament(id, name, desc);


### PR DESCRIPTION
## Description

- guildMemberRemove already filters for tournaments that are pending or in progress
- the bye commands have their own internal check
- cancel and finish have a status guard in their routines
- addhost and removehost are allowed for now because of topcut
- remaining commands are either read-only or already status gated at authenticateHost

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
