### PR TITLE
Fix register messages not being deleted and dropped pending players not being notified on tournament start

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 - Host commands can no longer be run in direct messages or other servers. (#223)
 - Participant commands can only be run in direct messages or the same server. (#238)
 - Tournaments can no longer be modified or dropped from after they finish. (#248)
+- Fix a bug with register messages not being deleted and dropped pending players not being notified on tournament start (#259)
 
 ## 2021-03-28 ([Chalislime Monthly March 2021](https://challonge.com/csmmar21))
 


### PR DESCRIPTION
## Description

The cause is trying to serialize an entity after it has been deleted, after which the object contains no useful information.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
