### PR TITLE
Shuffle players before starting tournament

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 - `mc!topcut` supports arbitrary size top cuts instead of specifically 8. The size is now required. (#231)
 - `mc!removehost` supports IDs to allow removing hosts who leave the server. (#234)
 - Responses use Discord replies where possible (#235)
+- Player seeds are shuffled before starting a tournament so that early sign-ups are not given an arbitrary advantage by their seed. (#266)
 
 ### Bug Fixes
 - Fix a typo in `mc!forcedrop` success message where it indicated confirmed participants were pending. (#236)

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -54,6 +54,8 @@ const command: CommandDefinition = {
 					.catch(logger.warn);
 			}
 			logger.verbose(log("notify ejected"));
+			await support.challonge.shufflePlayers(id); // must happen before byes assigned!
+			logger.verbose(log("shuffle players"));
 			await support.challonge.assignByes(id, tournament.byes);
 			logger.info(log("assign byes"));
 			await support.challonge.startTournament(id);

--- a/src/website/challonge.ts
+++ b/src/website/challonge.ts
@@ -457,4 +457,10 @@ export class WebsiteWrapperChallonge implements WebsiteWrapper {
 		);
 		return this.wrapPlayer(response);
 	}
+
+	public async shufflePlayers(tournamentId: string): Promise<void> {
+		await this.fetch(`${this.baseUrl}tournaments/${tournamentId}/participants/randomize.json`, {
+			method: "POST"
+		});
+	}
 }

--- a/src/website/interface.ts
+++ b/src/website/interface.ts
@@ -20,6 +20,7 @@ export interface WebsiteWrapper {
 	getPlayers(tournamentId: string): Promise<WebsitePlayer[]>;
 	setSeed(tournamentId: string, playerId: number, newSeed: number): Promise<void>;
 	getPlayer(tournamentId: string, playerId: number): Promise<WebsitePlayer>;
+	shufflePlayers(tournamentId: string): Promise<void>;
 }
 
 export interface WebsitePlayer {
@@ -284,5 +285,9 @@ export class WebsiteInterface {
 
 	public async getPlayer(...args: Parameters<WebsiteWrapper["getPlayer"]>): ReturnType<WebsiteWrapper["getPlayer"]> {
 		return await this.api.getPlayer(...args);
+	}
+
+	public async shufflePlayers(tournamentId: string): Promise<void> {
+		await this.api.shufflePlayers(tournamentId);
 	}
 }

--- a/test/mocks/website.ts
+++ b/test/mocks/website.ts
@@ -177,4 +177,7 @@ export class WebsiteWrapperMock implements WebsiteWrapper {
 	async getPlayer(): Promise<WebsitePlayer> {
 		throw new Error("Not implemented");
 	}
+	async shufflePlayers(): Promise<void> {
+		return;
+	}
 }


### PR DESCRIPTION
## Description

Ensures players who sign up earlier are not given an arbitrary seed advantage.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
