### PR TITLE
Cap filesize of submitted ydks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+## HEAD
+
+### New Features
+ - Submitted YDK files must now come in under a file size cap, for security. (#278)
 
 ## 2021-05-06 ([Chalislime Monthly April 2021](https://challonge.com/csmapr2021))
 

--- a/src/deck.ts
+++ b/src/deck.ts
@@ -85,8 +85,11 @@ export class DeckManager {
 			// cap filezie for security
 			if (msg.attachments[0].size > MAX_BYTES) {
 				// report potential abuse internally
-				logger.notify(`Potential abuse warning! User ${msg.author} submitted oversized deck file of ${msg.attachments[0].size}B.`)
-				throw new UserError("YDK file too large! Please try again with a smaller file.")
+				// TODO: Would be useful to report tournament and server, but we don't have that data in this scope
+				logger.notify(
+					`Potential abuse warning! User ${msg.author.id} (@${msg.author.username}#${msg.author.discriminator}) submitted oversized deck file of ${msg.attachments[0].size}B.`
+				);
+				throw new UserError("YDK file too large! Please try again with a smaller file.");
 			}
 			const ydk = await this.extractYdk(msg.attachments[0]); // throws on network error
 			const url = Deck.ydkToUrl(ydk); // throws YdkConstructionError

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -136,7 +136,7 @@ export async function onDirectMessage(
 // Throws on any problem with the deck, and the exception payload should be sent to the user
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 async function verifyDeck(msg: Message<PrivateChannel>, decks: DeckManager) {
-	const deck = await decks.getDeckFromMessage(msg); // throws on network error, YdkConstructionError, UrlConstructionError
+	const deck = await decks.getDeckFromMessage(msg); // throws on network error, YdkConstructionError, UrlConstructionError, filesize too big
 	const formattedDeckMessage = decks.prettyPrint(deck, `${msg.author.username}#${msg.author.discriminator}.ydk`);
 	if (deck.validationErrors.length > 0) {
 		await reply(msg, ...formattedDeckMessage).catch(logger.error);


### PR DESCRIPTION
## Description

Prevent DOS by overworking the prettyprint algorithm. Standard ydks are extremely small.
Call hierarchy, to justify representing this error by throwing:
- getDeckFromMessage is already expected to throw
- Called in verifyDeck, which is already expected to throw
- Called in verifyDeckAnd(ConfirmPending/UpdateConfirmed), already supposed to throw exceptions from verifyDeck
- Called in onDirectMessage which is not supposed to throw, trycatches the above commands, and replies with error details

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
