### PR TITLE
Fix topcut tournament id used in guides

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 ### Bug Fixes
 - Deck lists in private channels no longer display as "your deck". (#280)
 - Alternate artworks and other aliased cards are treated as the same card. (#280)
-- Guides for top cut now use the correct tournament id. (#281)
+- Guides for top cut now use the correct tournament id. (#282)
 
 ## 2021-05-06 ([Chalislime Monthly April 2021](https://challonge.com/csmapr2021))
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 - Deck lists in private channels no longer display as "your deck". (#280)
 - Alternate artworks and other aliased cards are treated as the same card. (#280)
+- Guides for top cut now use the correct tournament id. (#281)
 
 ## 2021-05-06 ([Chalislime Monthly April 2021](https://challonge.com/csmapr2021))
 

--- a/src/commands/topcut.ts
+++ b/src/commands/topcut.ts
@@ -74,13 +74,16 @@ const command: CommandDefinition = {
 		await support.database.startTournament(newId);
 		// send command guide to players
 		for (const channel of tournament.publicChannels) {
-			await support.discord.sendMessage(channel, support.templater.format("player", id));
+			await support.discord.sendMessage(channel, support.templater.format("player", newId));
 		}
 		// send command guide to hosts
 		for (const channel of tournament.privateChannels) {
-			await support.discord.sendMessage(channel, support.templater.format("start", id));
+			await support.discord.sendMessage(channel, support.templater.format("start", newId));
 		}
-		await reply(msg, `Top cut for **${tournament.name}** commenced on Challonge! Now sending out pairings.`);
+		await reply(
+			msg,
+			`Top cut for **${tournament.name}** commenced on Challonge! Use \`mc!round ${newId}\` to send out pairings and start the timer for round 1.`
+		);
 		// start new round
 	}
 };


### PR DESCRIPTION
## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
