### PR TITLE
mc!dump, mc!players: retrieve usernames from API if not cached

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 
 ### Bug Fixes
 - Restore tie command (#287)
+- `mc!dump`, `mc!players` retrieve usernames if not already cached (#295)
 
 ## 2021-05-28 ([Chalislime Monthly May 2021](https://challonge.com/csmmay2021))
 

--- a/src/commands/dump.ts
+++ b/src/commands/dump.ts
@@ -22,13 +22,17 @@ const command: CommandDefinition = {
 			})
 		);
 		const players = await support.database.getConfirmed(id);
-		const rows = players.map(player => {
-			const deck = support.decks.getDeck(player.deck);
-			return {
-				Player: support.discord.getUsername(player.discordId), // TODO: REST needed
-				Deck: `Main: ${deck.mainText}, Extra: ${deck.extraText}, Side: ${deck.sideText}`.replace(/\n/g, ", ")
-			};
-		});
+		const rows = await Promise.all(
+			players.map(async player => {
+				const deck = support.decks.getDeck(player.deck);
+				const username = (await support.discord.getRESTUsername(player.discordId)) || player.discordId;
+				const text = `Main: ${deck.mainText}, Extra: ${deck.extraText}, Side: ${deck.sideText}`;
+				return {
+					Player: username,
+					Deck: text.replace(/\n/g, ", ")
+				};
+			})
+		);
 		const file = await csv.writeToString(rows, { headers: true });
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/players.ts
+++ b/src/commands/players.ts
@@ -22,13 +22,15 @@ const command: CommandDefinition = {
 			})
 		);
 		const players = await support.database.getConfirmed(id);
-		const rows = players.map(player => {
-			const deck = support.decks.getDeck(player.deck);
-			return {
-				Player: support.discord.getUsername(player.discordId), // TODO: REST needed
-				Theme: deck.themes.length > 0 ? deck.themes.join("/") : "No themes"
-			};
-		});
+		const rows = await Promise.all(
+			players.map(async player => {
+				const deck = support.decks.getDeck(player.deck);
+				return {
+					Player: (await support.discord.getRESTUsername(player.discordId)) || player.discordId,
+					Theme: deck.themes.length > 0 ? deck.themes.join("/") : "No themes"
+				};
+			})
+		);
 		const file = await csv.writeToString(rows, { headers: true });
 		logger.verbose(
 			JSON.stringify({

--- a/test/commands/dump.unit.ts
+++ b/test/commands/dump.unit.ts
@@ -17,10 +17,12 @@ describe("command:dump", function () {
 				{ discordId: "1314", deck: "ydke://!!!", challongeId: 2 },
 				{ discordId: "1234", deck: "ydke://!!!", challongeId: 3 }
 			]);
+			const restStub = this.stub(support.discord, "getRESTUsername").resolves(null);
 			msg.channel.createMessage = this.spy();
 			await command.executor(msg, args, support);
 			expect(authStub).to.have.been.called;
 			expect(listStub).to.have.been.calledOnce;
+			expect(restStub).to.have.been.calledThrice;
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
 				sinon.match({ content: "Player decklists for Tournament battlecity is attached." }),
 				{

--- a/test/commands/forcescore.unit.ts
+++ b/test/commands/forcescore.unit.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai";
 import { User } from "eris";
-import sinon from "sinon";
+import sinon, { SinonSandbox } from "sinon";
 import command from "../../src/commands/forcescore";
-import { mockBotClient, msg, support } from "./common";
+import { mockBotClient, msg, support, test } from "./common";
 
 describe("command:forcescore", function () {
 	it("requires a mentioned user", async () => {
@@ -11,23 +11,26 @@ describe("command:forcescore", function () {
 		expect(command.executor(msg, ["name"], support)).to.be.rejectedWith("Message does not mention a user!");
 		expect(msg.channel.createMessage).to.not.have.been.called;
 	});
-	it("submits good scores", async () => {
-		msg.mentions = [new User({ id: "nova" }, mockBotClient)];
-		msg.channel.createMessage = sinon.spy();
-		sinon.stub(support.database, "getConfirmedPlayer").resolves({ challongeId: 0, discordId: "", deck: "" });
-		sinon.stub(support.challonge, "findClosedMatch").resolves({
-			player1: 0,
-			player2: 1,
-			matchId: 0,
-			open: true,
-			round: 1
-		});
-		sinon.stub(support.discord, "getRESTUsername").resolves("nova#0000");
-		await command.executor(msg, ["name", "2-1"], support);
-		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			sinon.match({ content: "Score of 2-1 submitted in favour of <@nova> (nova#0000) in **Tournament 1**!" })
-		);
-	});
+	it(
+		"submits good scores",
+		test(async function (this: SinonSandbox) {
+			msg.mentions = [new User({ id: "nova" }, mockBotClient)];
+			msg.channel.createMessage = sinon.spy();
+			this.stub(support.database, "getConfirmedPlayer").resolves({ challongeId: 0, discordId: "", deck: "" });
+			this.stub(support.challonge, "findClosedMatch").resolves({
+				player1: 0,
+				player2: 1,
+				matchId: 0,
+				open: true,
+				round: 1
+			});
+			this.stub(support.discord, "getRESTUsername").resolves("nova#0000");
+			await command.executor(msg, ["name", "2-1"], support);
+			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
+				sinon.match({ content: "Score of 2-1 submitted in favour of <@nova> (nova#0000) in **Tournament 1**!" })
+			);
+		})
+	);
 	it("rejects bad scores", () => {
 		msg.mentions = [new User({ id: "nova" }, mockBotClient)];
 		msg.channel.createMessage = sinon.spy();

--- a/test/commands/players.unit.ts
+++ b/test/commands/players.unit.ts
@@ -17,10 +17,12 @@ describe("command:players", function () {
 				{ discordId: "1314", deck: "ydke://!!!", challongeId: 2 },
 				{ discordId: "1234", deck: "ydke://!!!", challongeId: 3 }
 			]);
+			const restStub = this.stub(support.discord, "getRESTUsername").resolves(null);
 			msg.channel.createMessage = this.spy();
 			await command.executor(msg, args, support);
 			expect(authStub).to.have.been.called;
 			expect(listStub).to.have.been.calledOnce;
+			expect(restStub).to.have.been.calledThrice;
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
 				sinon.match({
 					content: "A list of players for tournament battlecity with the theme of their deck is attached."

--- a/test/commands/score.unit.ts
+++ b/test/commands/score.unit.ts
@@ -84,5 +84,6 @@ describe("command:score", function () {
 			"123",
 			"<@zeus> (nova#0000) and <@0000> (nova#0000) have reported their score of 1-2 for **foo** (name)."
 		);
+		sinon.resetBehavior();
 	});
 });


### PR DESCRIPTION
## Description

Longstanding! No more snowflakes in our CSVs (if the REST API responds)!

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
