### PR TITLE
Fix null propagation breaking regular registrations

### DIFF
--- a/src/database/orm/ChallongeTournament.ts
+++ b/src/database/orm/ChallongeTournament.ts
@@ -59,7 +59,7 @@ export class ChallongeTournament extends BaseEntity {
 	@Column("text", {
 		nullable: true,
 		transformer: {
-			from: (raw?: string) => raw && new Map(JSON.parse(raw)),
+			from: (raw: string | null) => (raw ? new Map(JSON.parse(raw)) : undefined),
 			to: (entity?: CardVector) => entity && JSON.stringify([...entity.entries()])
 		}
 	})


### PR DESCRIPTION
## Description

```
emcee:info:messageCreate {"event":"confirm fail","error":"Cannot read property 'get' of null"}
```

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
