### PR TITLE
Parse mentions without internal `!` for forcedrop and removehost

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 - Restore tie command (#287)
 - `mc!dump`, `mc!players` retrieve usernames if not already cached (#295)
+- Parse mentions without internal `!` for forcedrop and removehost (#300)
 
 ## 2021-05-28 ([Chalislime Monthly May 2021](https://challonge.com/csmmay2021))
 

--- a/src/commands/forcedrop.ts
+++ b/src/commands/forcedrop.ts
@@ -2,7 +2,7 @@ import { CommandDefinition } from "../Command";
 import { TournamentStatus } from "../database/interface";
 import { Participant } from "../database/orm";
 import { dropPlayerChallonge } from "../drop";
-import { reply } from "../util/discord";
+import { parseUserMention, reply } from "../util/discord";
 import { getLogger } from "../util/logger";
 
 const logger = getLogger("command:forcedrop");
@@ -13,7 +13,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		const [id, who] = args;
 		const tournament = await support.database.authenticateHost(id, msg.author.id, msg.guildID);
-		const player = who.startsWith("<@!") && who.endsWith(">") ? who.slice(3, -1) : who;
+		const player = parseUserMention(who) || who;
 		function log(payload: Record<string, unknown>): void {
 			logger.verbose(
 				JSON.stringify({

--- a/src/commands/removehost.ts
+++ b/src/commands/removehost.ts
@@ -1,5 +1,5 @@
 import { CommandDefinition } from "../Command";
-import { reply } from "../util/discord";
+import { parseUserMention, reply } from "../util/discord";
 import { getLogger } from "../util/logger";
 
 const logger = getLogger("command:removehost");
@@ -11,7 +11,7 @@ const command: CommandDefinition = {
 		// Mirror of addhost
 		const [id, who] = args;
 		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
-		const newHost = who.startsWith("<@!") && who.endsWith(">") ? who.slice(3, -1) : who;
+		const newHost = parseUserMention(who) || who;
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/util/discord.ts
+++ b/src/util/discord.ts
@@ -28,3 +28,15 @@ export function firstMentionOrFail(msg: Message): string {
 	}
 	return msg.mentions[0].id;
 }
+
+export function parseUserMention(who: string): string | null {
+	if (who.startsWith("<@") && who.endsWith(">")) {
+		if (who.charAt(2) === "!") {
+			return who.slice(3, -1);
+		} else {
+			return who.slice(2, -1);
+		}
+	} else {
+		return null;
+	}
+}


### PR DESCRIPTION
## Description

<@snowflake> and <@!snowflake> are both valid user mentions

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
