### PR TITLE
Interim patch for double drop silent failures

### DIFF
--- a/src/drop.ts
+++ b/src/drop.ts
@@ -90,7 +90,7 @@ export async function dropPlayerChallonge(
 				// If the match is closed AND the opponent has also dropped, the score is amended to a tie.
 				// Do not direct message the former opponent but do warn hosts of any errors.
 				// TODO: keep in mind when we change to tracking dropped players
-				const opponent = await database.getPlayerByChallonge(oppChallonge, tournamentId).catch<void>();
+				const opponent = await database.getPlayerByChallonge(oppChallonge, tournamentId).catch(() => undefined);
 				if (opponent) {
 					log({ tournamentId, oppChallonge, discordId: opponent.discordId });
 				} else {


### PR DESCRIPTION
## Description

The full problem needs further analysis, but this will stop the currently coded process from crapping out and instead work as the code intends. `.catch` on a Promise without a handler does nothing!

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
