### PR TITLE
Escape markdown characters from discord usernames

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## HEAD
--   `mc!dump`, `mc!players` and `mc!pie` have been merged into one command, `mc!csv`.
+### New Features
+- `mc!dump`, `mc!players` and `mc!pie` have been merged into one command, `mc!csv`. (#303)
+
+### Bug Fixes
+- Usernames printed in Discord will have markdown elements escaped, so they appear as written. (#304)
 
 ## 2021-06-27 ([Chalislime Monthly June 2021](https://challonge.com/csmjune2021))
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,102 +1,89 @@
 # Changelog
 
 ## HEAD
-
 -   `mc!dump`, `mc!players` and `mc!pie` have been merged into one command, `mc!csv`.
 
 ## 2021-06-27 ([Chalislime Monthly June 2021](https://challonge.com/csmjune2021))
 
 ### New Features
-
--   Enable configuring custom card pools through `mc!banlist` (#290)
--   If submitted scores disagree, the first submitter is notified (#296)
+- Enable configuring custom card pools through `mc!banlist` (#290)
+- If submitted scores disagree, the first submitter is notified (#296)
 
 ### Bug Fixes
-
--   Restore tie command (#287)
--   `mc!dump`, `mc!players` retrieve usernames if not already cached (#295)
--   Parse mentions without internal `!` for forcedrop and removehost (#300)
--   Interim patch for double drop silent failures (#301)
+- Restore tie command (#287)
+- `mc!dump`, `mc!players` retrieve usernames if not already cached (#295)
+- Parse mentions without internal `!` for forcedrop and removehost (#300)
+- Interim patch for double drop silent failures (#301)
 
 ## 2021-05-28 ([Chalislime Monthly May 2021](https://challonge.com/csmmay2021))
 
 ### New Features
-
--   Submitted YDK files must now come in under a file size cap, for security. (#278)
+- Submitted YDK files must now come in under a file size cap, for security. (#278)
 
 ### Bug Fixes
-
--   Deck lists in private channels no longer display as "your deck". (#280)
--   Alternate artworks and other aliased cards are treated as the same card. (#280)
--   Guides for top cut now use the correct tournament id. (#282)
+- Deck lists in private channels no longer display as "your deck". (#280)
+- Alternate artworks and other aliased cards are treated as the same card. (#280)
+- Guides for top cut now use the correct tournament id. (#282)
 
 ## 2021-05-06 ([Chalislime Monthly April 2021](https://challonge.com/csmapr2021))
 
 ### New Features
-
--   Deck resubmission policy is explicitly stated on submission. This was a frequently-asked question. (#230)
--   `mc!topcut` supports arbitrary size top cuts instead of specifically 8. The size is now required. (#231)
--   `mc!removehost` supports IDs to allow removing hosts who leave the server. (#234)
--   Responses use Discord replies where possible (#235)
--   Player seeds are shuffled before starting a tournament so that early sign-ups are not given an arbitrary advantage by their seed. (#266)
--   Apply a temporary fix to allow ANGU cards in decks.
+- Deck resubmission policy is explicitly stated on submission. This was a frequently-asked question. (#230)
+- `mc!topcut` supports arbitrary size top cuts instead of specifically 8. The size is now required. (#231)
+- `mc!removehost` supports IDs to allow removing hosts who leave the server. (#234)
+- Responses use Discord replies where possible (#235)
+- Player seeds are shuffled before starting a tournament so that early sign-ups are not given an arbitrary advantage by their seed. (#266)
+- Apply a temporary fix to allow ANGU cards in decks.
 
 ### Bug Fixes
-
--   Fix a typo in `mc!forcedrop` success message where it indicated confirmed participants were pending. (#236)
--   Fix a bug with users with IDs starting with 9 not receiving pairing direct messages. (#237)
--   Host commands can no longer be run in direct messages or other servers. (#223)
--   Participant commands can only be run in direct messages or the same server. (#238)
--   Tournaments can no longer be modified or dropped from after they finish. (#248)
--   Round 1 byes should now be assigned to the correct players consistently. (#249)
--   Fix a bug with register messages not being deleted and dropped pending players not being notified on tournament start (#259)
--   Fix eliminated players in top cut receiving direct messages about having a bye. (#260)
+- Fix a typo in `mc!forcedrop` success message where it indicated confirmed participants were pending. (#236)
+- Fix a bug with users with IDs starting with 9 not receiving pairing direct messages. (#237)
+- Host commands can no longer be run in direct messages or other servers. (#223)
+- Participant commands can only be run in direct messages or the same server. (#238)
+- Tournaments can no longer be modified or dropped from after they finish. (#248)
+- Round 1 byes should now be assigned to the correct players consistently. (#249)
+- Fix a bug with register messages not being deleted and dropped pending players not being notified on tournament start (#259)
+- Fix eliminated players in top cut receiving direct messages about having a bye. (#260)
 
 ## 2021-03-28 ([Chalislime Monthly March 2021](https://challonge.com/csmmar21))
 
 ### New Features
-
--   Emcee reports its current version in the `mc!help` command.
--   Starting the timer and sending the pairing for round 1 no longer happens automatically after `mc!start` and requires a manual call of `mc!round`. This is to allow for intervention if something goes wrong with the start process, before telling players to play.
--   Creating the Top Cut for a tournament is a separate `mc!topcut` command that can be called on a tournament after `mc!finish` is used. This allows taking a break between the end of Swiss and the start of Top Cut.
--   New `mc!tie` command changes all open matches in the current round to a tie. This is useful when a number of matches are outstanding at the end of a round or tournament.
--   A custom timer length can now be specified for `mc!round`.
--   Documentation is now up-to-date in this repository, replacing the wiki.
-
+- Emcee reports its current version in the `mc!help` command.
+- Starting the timer and sending the pairing for round 1 no longer happens automatically after `mc!start` and requires a manual call of `mc!round`. This is to allow for intervention if something goes wrong with the start process, before telling players to play.
+- Creating the Top Cut for a tournament is a separate `mc!topcut` command that can be called on a tournament after `mc!finish` is used. This allows taking a break between the end of Swiss and the start of Top Cut.
+- New `mc!tie` command changes all open matches in the current round to a tie. This is useful when a number of matches are outstanding at the end of a round or tournament.
+- A custom timer length can now be specified for `mc!round`.
+- Documentation is now up-to-date in this repository, replacing the wiki.
 ### Bug Fixes
-
--   The behaviour of dropping a player is now more reliable and consistent between a player using a command, a player unchecking their reaction, a host using `mc!forcedrop`, and a player leaving the server.
--   Deck submission should be more reliable and report errors.
--   Correctly identifies the natural bye, where it previously thought dropped players were still in the running.
--   Misc. stability updates including tournament commencement and identifying byes.
+- The behaviour of dropping a player is now more reliable and consistent between a player using a command, a player unchecking their reaction, a host using `mc!forcedrop`, and a player leaving the server.
+- Deck submission should be more reliable and report errors.
+- Correctly identifies the natural bye, where it previously thought dropped players were still in the running.
+- Misc. stability updates including tournament commencement and identifying byes.
 
 ## 2021-02-21 ([Chalislime Monthly February 2021](https://challonge.com/csmfeb21))
 
 ### New Features
-
--   Text updates to make the player guide clearer and cut down on questions.
--   New round messages now say which round it is.
--   When a player leaves the server they are automatically dropped from the tournament.
--   When both players in a match drop during that round, the match score will be amended to a tie instead of a victory for whoever dropped last.
-
+- Text updates to make the player guide clearer and cut down on questions.
+- New round messages now say which round it is.
+- When a player leaves the server they are automatically dropped from the tournament.
+- When both players in a match drop during that round, the match score will be amended to a tie instead of a victory for whoever dropped last.
 ### Bug Fixes
-
--   When a player submits a score to a match that's already closed (i.e. opponent has dropped), they're given an error message explaining instead of silently failing.
--   Correctly send a DM to the player with the round bye telling them so.
--   `mc!addbye`/`mc!removebye` commands print a correct read-out of which players currently have byes.
--   `mc!forcescore` can correctly change the score of a match that's already been submitted to, as long as it's still in the same round.
--   Cannot use `mc!addchannel`/`mc!removechannel` to add a channel other than the one the message is sent in, due to security concerns.
+- When a player submits a score to a match that's already closed (i.e. opponent has dropped), they're given an error message explaining instead of silently failing.
+- Correctly send a DM to the player with the round bye telling them so.
+- `mc!addbye`/`mc!removebye` commands print a correct read-out of which players currently have byes.
+- `mc!forcescore` can correctly change the score of a match that's already been submitted to, as long as it's still in the same round.
+- Cannot use `mc!addchannel`/`mc!removechannel` to add a channel other than the one the message is sent in, due to security concerns.
 
 ## 2021-01-05
 
--   Users can drop themselves in the middle of a tournament using a command. Hosts can still also drop users using a command.
--   Users can report scores for a match by using a command. Both users need to submit matching scores for it to be counted. Hosts can also report scores using a command by specifying the winner.
--   Emcee can export CSV spreadsheets featuring a list of all players alongside the archetype of their deck (ideal for casting a match), a list of all deck archetypes alongside a count of how many there are of that archetype (ideal for making a pie chart), or a list of all players alongside their decklist (ideal for seeing how many of a card is played).
--   Emcee outputs the Username#1234 with the decklist for easier searchability.
--   Downloading YDK files should now work properly, hopefully, or it did already, it's not super clear.
--   Emcee now has a new deck reading system that should have up-to-date lists and if necessary can be tweaked to allow a different set of allowed cards without needing a custom banlist that falls out of date.
--   Players can now change their deck for a Tournament they're registered in by sending Emcee a new one, without dropping.
--   At the start of a round, Emcee will post a 50:00 countdown timer that updates every 5 seconds. When it runs out, Emcee will ping all players and instruct them to conduct end of round procedures. Starting the next round early will cancel the previous timer.
--   At the end of a Swiss tournament, Emcee will take the Top 8 players and put them into a single-elimination tournament automatically. This will be registered as a tournament that operates through Emcee as well.
--   Emcee's deck reading system is set up to check decks for archetypes in a more structured manner, once we've decided what criteria to look for.
--   Emcee can now be told to give certain players a round 1 bye. When the tournament starts, it will create dummy players and make sure players with byes are matched up to them and given a 2-0. Once the tournament has commenced, the dummy players will be dropped.
+- Users can drop themselves in the middle of a tournament using a command. Hosts can still also drop users using a command.
+- Users can report scores for a match by using a command. Both users need to submit matching scores for it to be counted. Hosts can also report scores using a command by specifying the winner.
+- Emcee can export CSV spreadsheets featuring a list of all players alongside the archetype of their deck (ideal for casting a match), a list of all deck archetypes alongside a count of how many there are of that archetype (ideal for making a pie chart), or a list of all players alongside their decklist (ideal for seeing how many of a card is played).
+- Emcee outputs the Username#1234 with the decklist for easier searchability.
+- Downloading YDK files should now work properly, hopefully, or it did already, it's not super clear.
+- Emcee now has a new deck reading system that should have up-to-date lists and if necessary can be tweaked to allow a different set of allowed cards without needing a custom banlist that falls out of date.
+- Players can now change their deck for a Tournament they're registered in by sending Emcee a new one, without dropping.
+- At the start of a round, Emcee will post a 50:00 countdown timer that updates every 5 seconds. When it runs out, Emcee will ping all players and instruct them to conduct end of round procedures. Starting the next round early will cancel the previous timer.
+- At the end of a Swiss tournament, Emcee will take the Top 8 players and put them into a single-elimination tournament automatically. This will be registered as a tournament that operates through Emcee as well.
+- Emcee's deck reading system is set up to check decks for archetypes in a more structured manner, once we've decided what criteria to look for.
+- Emcee can now be told to give certain players a round 1 bye. When the tournament starts, it will create dummy players and make sure players with byes are matched up to them and given a 2-0. Once the tournament has commenced, the dummy players will be dropped.

--- a/src/TournamentManager.ts
+++ b/src/TournamentManager.ts
@@ -105,7 +105,8 @@ export class TournamentManager implements TournamentInterface {
 				await this.discord.sendMessage(
 					c,
 					`Player ${this.discord.mentionUser(playerId)} (${this.discord.getUsername(
-						playerId
+						playerId,
+						true
 					)}) is trying to sign up for Tournament ${tournament.name} (${
 						tournament.id
 					}), but I cannot send them DMs. Please ask them to allow DMs from this server.`

--- a/src/commands/addbye.ts
+++ b/src/commands/addbye.ts
@@ -34,7 +34,8 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		const tag = (id: string): string => `${support.discord.mentionUser(id)} (${support.discord.getUsername(id)})`;
+		const tag = (id: string): string =>
+			`${support.discord.mentionUser(id)} (${support.discord.getUsername(id, true)})`;
 		const names = byes.map(tag).join(", ");
 		await reply(msg, `Bye registered for Player ${tag(player)} in Tournament ${id}!\nAll byes: ${names}`);
 	}

--- a/src/commands/forcedrop.ts
+++ b/src/commands/forcedrop.ts
@@ -28,7 +28,7 @@ const command: CommandDefinition = {
 		}
 		log({ player, event: "attempt" });
 		const participant = await Participant.findOne({ tournamentId: id, discordId: player });
-		const username = await support.discord.getRESTUsername(player);
+		const username = await support.discord.getRESTUsername(player, true);
 		log({ player, exists: !!participant, challongeId: participant?.confirmed?.challongeId, username });
 		const name = username ? `<@${player}> (${username})` : who;
 		if (!participant) {

--- a/src/commands/forcescore.ts
+++ b/src/commands/forcescore.ts
@@ -61,7 +61,7 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		const username = await support.discord.getRESTUsername(player);
+		const username = await support.discord.getRESTUsername(player, true);
 		await reply(
 			msg,
 			`Score of ${scores[0]}-${scores[1]} submitted in favour of <@${player}> (${username}) in **${tournament.name}**!`

--- a/src/commands/removebye.ts
+++ b/src/commands/removebye.ts
@@ -35,7 +35,8 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		const tag = (id: string): string => `${support.discord.mentionUser(id)} (${support.discord.getUsername(id)})`;
+		const tag = (id: string): string =>
+			`${support.discord.mentionUser(id)} (${support.discord.getUsername(id, true)})`;
 		const names = byes.map(tag).join(", ");
 		await reply(msg, `Bye removed for Player ${tag(player)} in Tournament ${id}!\nAll byes: ${names}`);
 	}

--- a/src/commands/score.ts
+++ b/src/commands/score.ts
@@ -87,8 +87,8 @@ const command: CommandDefinition = {
 				}
 				// Inform the hosts
 				try {
-					const callerUsername = await support.discord.getRESTUsername(msg.author.id);
-					const opponentUsername = await support.discord.getRESTUsername(opponent);
+					const callerUsername = await support.discord.getRESTUsername(msg.author.id, true);
+					const opponentUsername = await support.discord.getRESTUsername(opponent, true);
 					log("notify", { callerUsername, opponentUsername });
 					for (const channel of player.tournament.privateChannels) {
 						await support.discord.sendMessage(

--- a/src/commands/topcut.ts
+++ b/src/commands/topcut.ts
@@ -55,7 +55,7 @@ const command: CommandDefinition = {
 		for (const player of top) {
 			const challongeId = await support.challonge.registerPlayer(
 				newId,
-				support.discord.getUsername(player.discordId),
+				support.discord.getUsername(player.discordId, false),
 				player.discordId
 			);
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/commands/topcut.ts
+++ b/src/commands/topcut.ts
@@ -55,7 +55,7 @@ const command: CommandDefinition = {
 		for (const player of top) {
 			const challongeId = await support.challonge.registerPlayer(
 				newId,
-				support.discord.getUsername(player.discordId, false),
+				support.discord.getUsername(player.discordId),
 				player.discordId
 			);
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/discord/interface.ts
+++ b/src/discord/interface.ts
@@ -130,7 +130,7 @@ export class DiscordInterface {
 	}
 
 	private escapeUsername(username: string): string {
-		const mdEscape = /([\\*_`>])/g;
+		const mdEscape = /([\\*_`>~])/g;
 		return username.replace(mdEscape, "\\$1");
 	}
 

--- a/src/discord/interface.ts
+++ b/src/discord/interface.ts
@@ -129,7 +129,7 @@ export class DiscordInterface {
 		await this.api.deleteMessage(channelId, messageId);
 	}
 
-	private escapeUsername(username: string): string {
+	public escapeUsername(username: string): string {
 		const mdEscape = /([\\*_`>~])/g;
 		return username.replace(mdEscape, "\\$1");
 	}

--- a/src/discord/interface.ts
+++ b/src/discord/interface.ts
@@ -130,7 +130,7 @@ export class DiscordInterface {
 	}
 
 	public escapeUsername(username: string): string {
-		const mdEscape = /([\\*_`>~])/g;
+		const mdEscape = /([\\*_`<>:~])/g;
 		return username.replace(mdEscape, "\\$1");
 	}
 

--- a/src/discord/interface.ts
+++ b/src/discord/interface.ts
@@ -130,7 +130,7 @@ export class DiscordInterface {
 	}
 
 	public escapeUsername(username: string): string {
-		const mdEscape = /([\\*_`<>:~])/g;
+		const mdEscape = /([\\*_`~])/g;
 		return username.replace(mdEscape, "\\$1");
 	}
 

--- a/src/discord/interface.ts
+++ b/src/discord/interface.ts
@@ -129,12 +129,20 @@ export class DiscordInterface {
 		await this.api.deleteMessage(channelId, messageId);
 	}
 
-	public getUsername(userId: string): string {
-		return this.api.getUsername(userId);
+	private escapeUsername(username: string): string {
+		const mdEscape = /([\\*_`>])/g;
+		return username.replace(mdEscape, "\\$1");
 	}
 
-	public async getRESTUsername(userId: string): Promise<string | null> {
-		return await this.api.getRESTUsername(userId);
+	// escape markdown characters if destination is discord, but not if being printed into a file, filename, challonge, etc
+	public getUsername(userId: string, escape = true): string {
+		const name = this.api.getUsername(userId);
+		return escape ? this.escapeUsername(name) : name;
+	}
+
+	public async getRESTUsername(userId: string, escape = true): Promise<string | null> {
+		const name = await this.api.getRESTUsername(userId);
+		return name && escape ? this.escapeUsername(name) : name;
 	}
 
 	public async sendDirectMessage(userId: string, content: DiscordMessageOut): Promise<void> {

--- a/src/discord/interface.ts
+++ b/src/discord/interface.ts
@@ -135,12 +135,12 @@ export class DiscordInterface {
 	}
 
 	// escape markdown characters if destination is discord, but not if being printed into a file, filename, challonge, etc
-	public getUsername(userId: string, escape = true): string {
+	public getUsername(userId: string, escape = false): string {
 		const name = this.api.getUsername(userId);
 		return escape ? this.escapeUsername(name) : name;
 	}
 
-	public async getRESTUsername(userId: string, escape = true): Promise<string | null> {
+	public async getRESTUsername(userId: string, escape = false): Promise<string | null> {
 		const name = await this.api.getRESTUsername(userId);
 		return name && escape ? this.escapeUsername(name) : name;
 	}

--- a/src/round.ts
+++ b/src/round.ts
@@ -63,11 +63,12 @@ export async function advanceRoundDiscord(
 			const player1 = players.get(match.player1);
 			const player2 = players.get(match.player2);
 			if (player1 && player2) {
-				const name1 = await getRealUsername(discord, player1);
-				const name2 = await getRealUsername(discord, player2);
-				// names are escaped because they will be printed to discord, but this has consequences for logging
-				// TODO: expose escape function as public to resolve this specific case?
+				let name1 = await getRealUsername(discord, player1);
+				let name2 = await getRealUsername(discord, player2);
 				logger.verbose({ tournament: tournament.id, match: match.matchId, player1, player2, name1, name2 });
+				// escape names for Discord printing now that we've logged them
+				name1 = name1 && discord.escapeUsername(name1);
+				name2 = name2 && discord.escapeUsername(name2);
 				if (name1) {
 					await sendPairing(discord, intro, player1, player2, name2, tournament);
 				} else {
@@ -142,7 +143,7 @@ async function getRealUsername(discord: DiscordInterface, userId: string): Promi
 	if (notSnowflake(userId)) {
 		return null;
 	}
-	return await discord.getRESTUsername(userId, true);
+	return await discord.getRESTUsername(userId); //we need it both escaped and unescaped, so we'll escape manually later
 }
 
 async function sendPairing(

--- a/src/round.ts
+++ b/src/round.ts
@@ -142,7 +142,7 @@ async function getRealUsername(discord: DiscordInterface, userId: string): Promi
 	if (notSnowflake(userId)) {
 		return null;
 	}
-	return await discord.getRESTUsername(userId);
+	return await discord.getRESTUsername(userId, true);
 }
 
 async function sendPairing(

--- a/src/round.ts
+++ b/src/round.ts
@@ -65,6 +65,8 @@ export async function advanceRoundDiscord(
 			if (player1 && player2) {
 				const name1 = await getRealUsername(discord, player1);
 				const name2 = await getRealUsername(discord, player2);
+				// names are escaped because they will be printed to discord, but this has consequences for logging
+				// TODO: expose escape function as public to resolve this specific case?
 				logger.verbose({ tournament: tournament.id, match: match.matchId, player1, player2, name1, name2 });
 				if (name1) {
 					await sendPairing(discord, intro, player1, player2, name2, tournament);

--- a/test/discord.ts
+++ b/test/discord.ts
@@ -23,16 +23,16 @@ describe("Simple helpers", function () {
 
 describe("getUsername", function () {
 	it("No special characters", function () {
-		expect(discord.getUsername("player1")).to.equal("player1");
+		expect(discord.getUsername("player1", true)).to.equal("player1");
 	});
 	it("Successful escape", function () {
-		expect(discord.getUsername("player_1")).to.equal("player\\_1");
+		expect(discord.getUsername("player_1", true)).to.equal("player\\_1");
 	});
 	it("Successful escape backslash", function () {
-		expect(discord.getUsername("player\\1")).to.equal("player\\\\1");
+		expect(discord.getUsername("player\\1", true)).to.equal("player\\\\1");
 	});
 	it("There is no escape", function () {
-		expect(discord.getUsername("player_1", false)).to.equal("player_1");
+		expect(discord.getUsername("player_1")).to.equal("player_1");
 	});
 });
 

--- a/test/discord.ts
+++ b/test/discord.ts
@@ -19,9 +19,20 @@ describe("Simple helpers", function () {
 	it("mentionRole", function () {
 		expect(discord.mentionRole("role")).to.equal("<@&role>");
 	});
+});
 
-	it("getUsername", function () {
+describe("getUsername", function () {
+	it("No special characters", function () {
 		expect(discord.getUsername("player1")).to.equal("player1");
+	});
+	it("Successful escape", function () {
+		expect(discord.getUsername("player_1")).to.equal("player\\_1");
+	});
+	it("Successful escape backslash", function () {
+		expect(discord.getUsername("player\\1")).to.equal("player\\\\1");
+	});
+	it("There is no escape", function () {
+		expect(discord.getUsername("player_1", false)).to.equal("player_1");
 	});
 });
 


### PR DESCRIPTION
## Description

This option is on by default but has a parameter to disable it for when usernames are printed to non-discord sources.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
