### PR TITLE
Add command mc!capacity to read and set the participant limit of preparing tournaments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 ### New Features
 - `mc!dump`, `mc!players` and `mc!pie` have been merged into one command, `mc!csv`. (#303)
 - Participant limits are enforced (#313)
+- Add command `mc!capacity` to read and set the participant limit of preparing tournaments (#315)
 
 ### Bug Fixes
 - Usernames printed in Discord will have markdown elements escaped, so they appear as written. (#304)

--- a/docs/usage-organiser.md
+++ b/docs/usage-organiser.md
@@ -40,6 +40,7 @@ They may be truncated with length. Make sure to update these if you change a hea
 
 ### Before starting a tournament
 1. [mc!update](#update-tournament-information)
+1. [mc!capacity](#set-or-read-tournament-capacity)
 1. [mc!removehost](#remove-host)
 1. [mc!removechannel](#remove-announcement-channel)
 1. [mc!addbye](#add-artificial-round-one-bye)
@@ -134,6 +135,26 @@ mc!update id|name|description
 The specified tournament must be in the preparing stage and not have been started.
 Updates the name and description for the tournament, affecting the Challonge page
 and future sign-up messages.
+
+
+### Set or read tournament capacity
+```
+mc!capacity id|limit
+```
+**Caller permission level**: host for the tournament identified by _id_
+
+`limit` must be a whole number. It may be omitted, in which case this reads the
+tournament capacity instead.
+
+The specified tournament must be in the preparing stage and not have been started.
+
+If `limit` is omitted, this retrieves the current participant limit. Note that
+the default maximum is 256, enforced by Challonge's free [Standard Plan](https://challonge.com/pricing).
+
+If `limit` is provided, the participant limit is set to the provided value. Using
+`0` will disable this feature from Emcee's side as it is by default, but the
+aforementioned limits from Challonge continue to apply, so it will display as 256.
+For the same reason, setting the capacity above 256 will not have a meaningful effect.
 
 ### Open tournament for registrations
 ```

--- a/guides/create.template.md
+++ b/guides/create.template.md
@@ -20,6 +20,9 @@ mc!removehost {}|@User```
 You can change the name and description.
 ```
 mc!update {}|New Name|A new description```
+You can set a smaller capacity than Challonge Standard: https://challonge.com/pricing
+```
+mc!capacity {}|limit```
 **Open sign-ups**
 This posts the registration message to all public channels.
 Further details on your next steps will be sent to private channels.

--- a/src/commands/capacity.ts
+++ b/src/commands/capacity.ts
@@ -1,0 +1,48 @@
+import { CommandDefinition } from "../Command";
+import { TournamentStatus } from "../database/interface";
+import { ChallongeTournament } from "../database/orm";
+import { reply } from "../util/discord";
+import { UserError } from "../util/errors";
+import { getLogger } from "../util/logger";
+
+const logger = getLogger("command:capacity");
+
+const command: CommandDefinition = {
+	name: "capacity",
+	requiredArgs: ["id"],
+	executor: async (msg, args, support) => {
+		const [id, rawCapacity] = args; // 1 optional and thus potentially undefined
+		const capacity = parseInt(rawCapacity, 10);
+		logger.verbose(
+			JSON.stringify({
+				channel: msg.channel.id,
+				message: msg.id,
+				user: msg.author.id,
+				tournament: id,
+				command: "capacity",
+				capacity
+			})
+		);
+		if (rawCapacity && (isNaN(capacity) || capacity < 0 || `${capacity}` !== rawCapacity)) {
+			throw new UserError("The second parameter (tournament capacity) must be a whole number!");
+		}
+		const tournament = await support.database.authenticateHost(
+			id,
+			msg.author.id,
+			msg.guildID,
+			TournamentStatus.PREPARING
+		);
+		if (rawCapacity) {
+			await ChallongeTournament.createQueryBuilder()
+				.update()
+				.set({ participantLimit: capacity })
+				.where({ tournamentId: id })
+				.execute();
+			await reply(msg, `Set the capacity for **${tournament.name}** to _${capacity}_.`);
+		} else {
+			await reply(msg, `**${tournament.name}** capacity: _${tournament.limit || 256}_`);
+		}
+	}
+};
+
+export default command;

--- a/src/commands/capacity.ts
+++ b/src/commands/capacity.ts
@@ -12,7 +12,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id, rawCapacity] = args; // 1 optional and thus potentially undefined
-		const capacity = parseInt(rawCapacity, 10);
+		let capacity = parseInt(rawCapacity, 10);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,
@@ -25,6 +25,9 @@ const command: CommandDefinition = {
 		);
 		if (rawCapacity && (isNaN(capacity) || capacity < 0 || `${capacity}` !== rawCapacity)) {
 			throw new UserError("The second parameter (tournament capacity) must be a whole number!");
+		}
+		if (capacity > 256) {
+			capacity = 0;
 		}
 		const tournament = await support.database.authenticateHost(
 			id,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,6 +3,7 @@ export { default as addchannel } from "./addchannel";
 export { default as addhost } from "./addhost";
 export { default as banlist } from "./banlist";
 export { default as cancel } from "./cancel";
+export { default as capacity } from "./capacity";
 export { default as create } from "./create";
 export { default as csv } from "./csv";
 export { default as deck } from "./deck";

--- a/test/commands/capacity.unit.ts
+++ b/test/commands/capacity.unit.ts
@@ -1,0 +1,112 @@
+import { expect } from "chai";
+import sinon, { SinonSandbox } from "sinon";
+import command from "../../src/commands/capacity";
+import { DatabaseTournament, TournamentFormat, TournamentStatus } from "../../src/database/interface";
+import { ChallongeTournament } from "../../src/database/orm";
+import { itRejectsNonHosts, msg, support, test } from "./common";
+
+describe("command:capacity", function () {
+	const tournament: DatabaseTournament = {
+		name: "foo",
+		limit: 16,
+		// unused
+		id: "",
+		description: "",
+		format: TournamentFormat.SWISS,
+		status: TournamentStatus.PREPARING,
+		hosts: [],
+		players: [],
+		publicChannels: [],
+		privateChannels: [],
+		server: "r",
+		byes: [],
+		findPlayer: () => undefined
+	};
+	itRejectsNonHosts(support, command, msg, ["name"]);
+	it("rejects badly formatted numbers", () => {
+		const error = "The second parameter (tournament capacity) must be a whole number!";
+		for (const example in [
+			"1.1",
+			"4000.56",
+			"0x2",
+			"0xB",
+			"02",
+			"007",
+			"ab",
+			"fourteen",
+			"-2",
+			"-54.3",
+			"10 000",
+			"20,000"
+		]) {
+			expect(command.executor(msg, ["name", example], support)).to.be.rejectedWith(error);
+		}
+	});
+	it(
+		"returns the participant limit",
+		test(async function (this: SinonSandbox) {
+			this.stub(support.database, "authenticateHost").resolves(tournament);
+			msg.channel.createMessage = this.spy();
+			await command.executor(msg, ["name"], support);
+			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
+				sinon.match({ content: `**foo** capacity: _16_` })
+			);
+		})
+	);
+	it(
+		"returns 0 capacity as 256",
+		test(async function (this: SinonSandbox) {
+			this.stub(support.database, "authenticateHost").resolves({
+				...tournament,
+				limit: 0
+			});
+			msg.channel.createMessage = this.spy();
+			await command.executor(msg, ["name"], support);
+			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
+				sinon.match({ content: `**foo** capacity: _256_` })
+			);
+		})
+	);
+	it(
+		"sets the participant limit",
+		test(async function (this: SinonSandbox) {
+			this.stub(support.database, "authenticateHost").resolves(tournament);
+			this.stub(ChallongeTournament, "createQueryBuilder").returns({
+				update: () => ({
+					set: () => ({
+						where: () => ({
+							execute: () => undefined
+						})
+					})
+				})
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any);
+			msg.channel.createMessage = this.spy();
+			await command.executor(msg, ["name", "32"], support);
+			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
+				sinon.match({ content: `Set the capacity for **foo** to _32_.` })
+			);
+		})
+	);
+	it(
+		"treats oversized limits as zero",
+		test(async function (this: SinonSandbox) {
+			this.stub(support.database, "authenticateHost").resolves(tournament);
+			this.stub(ChallongeTournament, "createQueryBuilder").returns({
+				update: () => ({
+					set: () => ({
+						where: () => ({
+							execute: () => undefined
+						})
+					})
+				})
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any);
+			msg.channel.createMessage = this.spy();
+			await command.executor(msg, ["name", "512"], support);
+			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
+				sinon.match({ content: `Set the capacity for **foo** to _0_.` })
+			);
+		})
+	);
+});

--- a/test/commands/capacity.unit.ts
+++ b/test/commands/capacity.unit.ts
@@ -25,7 +25,7 @@ describe("command:capacity", function () {
 	itRejectsNonHosts(support, command, msg, ["name"]);
 	it("rejects badly formatted numbers", () => {
 		const error = "The second parameter (tournament capacity) must be a whole number!";
-		for (const example in [
+		for (const example of [
 			"1.1",
 			"4000.56",
 			"0x2",


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

The generated query is
```sql
UPDATE "challonge_tournament" SET "participantLimit" = $2 WHERE "tournamentId" = $1;
```

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
