### PR TITLE
Print bold tournament name instead of ID in command responses

### DIFF
--- a/src/commands/addbye.ts
+++ b/src/commands/addbye.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
+		const tournament = await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const player = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({
@@ -37,7 +37,7 @@ const command: CommandDefinition = {
 		const tag = (id: string): string =>
 			`${support.discord.mentionUser(id)} (${support.discord.getUsername(id, true)})`;
 		const names = byes.map(tag).join(", ");
-		await reply(msg, `Bye registered for Player ${tag(player)} in Tournament ${id}!\nAll byes: ${names}`);
+		await reply(msg, `Bye registered for Player ${tag(player)} in **${tournament.name}**!\nAll byes: ${names}`);
 	}
 };
 

--- a/src/commands/addchannel.ts
+++ b/src/commands/addchannel.ts
@@ -45,10 +45,10 @@ const command: CommandDefinition = {
 		/* No longer required as will always be in same channel as reply
 		await reply(
 			msg,
-			`${support.discord.mentionChannel(channelId)} added as a ${type} announcement channel for Tournament ${id}!`
+			`${support.discord.mentionChannel(channelId)} added as a ${type} announcement channel for **${tournament.name}**!`
 		);
 		*/
-		await reply(msg, `This channel added as a ${type} announcement channel for Tournament ${id}!`);
+		await reply(msg, `This channel added as a ${type} announcement channel for **${tournament.name}**!`);
 	}
 };
 

--- a/src/commands/addhost.ts
+++ b/src/commands/addhost.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
+		const tournament = await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const newHost = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/addhost.ts
+++ b/src/commands/addhost.ts
@@ -34,7 +34,7 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		await reply(msg, `${support.discord.mentionUser(newHost)} added as a host for Tournament ${id}!`);
+		await reply(msg, `${support.discord.mentionUser(newHost)} added as a host for **${tournament.name}**!`);
 	}
 };
 

--- a/src/commands/csv.ts
+++ b/src/commands/csv.ts
@@ -11,7 +11,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		const [id, pieArg] = args;
 		const pie = !!pieArg;
-		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
+		const tournament = await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/csv.ts
+++ b/src/commands/csv.ts
@@ -25,7 +25,7 @@ const command: CommandDefinition = {
 		);
 		const players = await support.database.getConfirmed(id);
 		if (players.length < 1) {
-			await reply(msg, `Tournament ${id} has no players!`);
+			await reply(msg, `**${tournament.name}** has no players!`);
 			return;
 		}
 		let file;

--- a/src/commands/finish.ts
+++ b/src/commands/finish.ts
@@ -28,7 +28,7 @@ const command: CommandDefinition = {
 			if (!early) {
 				await reply(
 					msg,
-					`Tournament ${id} is not finished. If you intend to end it early, use \`mc!finish ${id}|early\`.`
+					`**${tournament.name}** is not finished. If you intend to end it early, use \`mc!finish ${id}|early\`.`
 				);
 				return;
 			}
@@ -45,7 +45,7 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		await reply(msg, `Tournament ${id} successfully finished.`);
+		await reply(msg, `**${tournament.name}** successfully finished.`);
 	}
 };
 

--- a/src/commands/finish.ts
+++ b/src/commands/finish.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		const [id, earlyArg] = args;
 		const early = !!earlyArg;
-		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
+		const tournament = await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -9,7 +9,7 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
+		const tournament = await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -31,7 +31,7 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		await reply(msg, `Tournament ${id} opened for registration!`);
+		await reply(msg, `**${tournament.name}** opened for registration!`);
 	}
 };
 

--- a/src/commands/removebye.ts
+++ b/src/commands/removebye.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// Mirror of addbye
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
+		const tournament = await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const player = firstMentionOrFail(msg);
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/removebye.ts
+++ b/src/commands/removebye.ts
@@ -38,7 +38,7 @@ const command: CommandDefinition = {
 		const tag = (id: string): string =>
 			`${support.discord.mentionUser(id)} (${support.discord.getUsername(id, true)})`;
 		const names = byes.map(tag).join(", ");
-		await reply(msg, `Bye removed for Player ${tag(player)} in Tournament ${id}!\nAll byes: ${names}`);
+		await reply(msg, `Bye removed for Player ${tag(player)} in **${tournament.name}**!\nAll byes: ${names}`);
 	}
 };
 

--- a/src/commands/removechannel.ts
+++ b/src/commands/removechannel.ts
@@ -47,9 +47,9 @@ const command: CommandDefinition = {
 			msg,
 			`${support.discord.mentionChannel(
 				channelId
-			)} removed as a ${type} announcement channel for Tournament ${id}!`
+			)} removed as a ${type} announcement channel for **${tournament.name}**!`
 		); */
-		await reply(msg, `This channel removed as a ${type} announcement channel for Tournament ${id}!`);
+		await reply(msg, `This channel removed as a ${type} announcement channel for **${tournament.name}**!`);
 	}
 };
 

--- a/src/commands/removehost.ts
+++ b/src/commands/removehost.ts
@@ -35,7 +35,7 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		await reply(msg, `${support.discord.mentionUser(newHost)} removed as a host for Tournament ${id}!`);
+		await reply(msg, `${support.discord.mentionUser(newHost)} removed as a host for **${tournament.name}**!`);
 	}
 };
 

--- a/src/commands/removehost.ts
+++ b/src/commands/removehost.ts
@@ -10,7 +10,7 @@ const command: CommandDefinition = {
 	executor: async (msg, args, support) => {
 		// Mirror of addhost
 		const [id, who] = args;
-		await support.database.authenticateHost(id, msg.author.id, msg.guildID);
+		const tournament = await support.database.authenticateHost(id, msg.author.id, msg.guildID);
 		const newHost = parseUserMention(who) || who;
 		logger.verbose(
 			JSON.stringify({

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -51,7 +51,7 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		await reply(msg, `Tournament ${id} database successfully synchronised with remote website.`);
+		await reply(msg, `**${tournament.name}** database successfully synchronised with remote website.`);
 	}
 };
 

--- a/src/commands/tb.ts
+++ b/src/commands/tb.ts
@@ -62,7 +62,9 @@ const command: CommandDefinition = {
 		if (!tb2 || !tb3 || !(tb1 in realTBNames) || !(tb2 in realTBNames) || !(tb3 in realTBNames)) {
 			await reply(
 				msg,
-				`Could not update tie-breakers for Tournament ${id}. You must provide three valid options in priority order. The valid options and their corresponding meaning are:\n${Object.entries(
+				`Could not update tie-breakers for **${
+					tournament.name
+				}**. You must provide three valid options in priority order. The valid options and their corresponding meaning are:\n${Object.entries(
 					realTBNames
 				)
 					.map(tb => `\`${tb[0]}\` (${tb[1]})`)
@@ -74,7 +76,7 @@ const command: CommandDefinition = {
 		await support.challonge.updateTieBreakers(id, [tb1, tb2, tb3] as ChallongeTieBreaker[]);
 		await reply(
 			msg,
-			`Tie-breaker settings updated for Tournament ${id}.\n${[tb1, tb2, tb3]
+			`Tie-breaker settings updated for **${tournament.name}**.\n${[tb1, tb2, tb3]
 				.map((tb, i) => `${i + 1}. ${realTBNames[tb as ChallongeTieBreaker]}`)
 				.join("\n")}`
 		);

--- a/src/commands/tie.ts
+++ b/src/commands/tie.ts
@@ -10,7 +10,12 @@ const command: CommandDefinition = {
 	requiredArgs: ["id"],
 	executor: async (msg, args, support) => {
 		const [id] = args;
-		await support.database.authenticateHost(id, msg.author.id, msg.guildID, TournamentStatus.IPR);
+		const tournament = await support.database.authenticateHost(
+			id,
+			msg.author.id,
+			msg.guildID,
+			TournamentStatus.IPR
+		);
 		logger.verbose(
 			JSON.stringify({
 				channel: msg.channel.id,

--- a/src/commands/tie.ts
+++ b/src/commands/tie.ts
@@ -38,7 +38,10 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		await reply(msg, `All outstanding matches in Round ${round} of Tournament ${id} successfully ended in a tie!`);
+		await reply(
+			msg,
+			`All outstanding matches in Round ${round} of **${tournament.name}** successfully ended in a tie!`
+		);
 	}
 };
 

--- a/test/commands/addbye.unit.ts
+++ b/test/commands/addbye.unit.ts
@@ -21,7 +21,7 @@ describe("command:addbye", function () {
 			await command.executor(msg, ["name"], support);
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
 				sinon.match({
-					content: "Bye registered for Player <@nova> (nova) in Tournament name!\nAll byes: "
+					content: "Bye registered for Player <@nova> (nova) in **Tournament 1**!\nAll byes: "
 				})
 			);
 		})

--- a/test/commands/addchannel.unit.ts
+++ b/test/commands/addchannel.unit.ts
@@ -17,7 +17,7 @@ describe("command:addchannel", function () {
 				"public"
 			);
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-				sinon.match({ content: "This channel added as a public announcement channel for Tournament name!" })
+				sinon.match({ content: "This channel added as a public announcement channel for **Tournament 1**!" })
 			);
 		})
 	);
@@ -33,7 +33,7 @@ describe("command:addchannel", function () {
 				"public"
 			);
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-				sinon.match({ content: "This channel added as a public announcement channel for Tournament name!" })
+				sinon.match({ content: "This channel added as a public announcement channel for **Tournament 1**!" })
 			);
 		})
 	);
@@ -49,7 +49,7 @@ describe("command:addchannel", function () {
 				"private"
 			);
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-				sinon.match({ content: "This channel added as a private announcement channel for Tournament name!" })
+				sinon.match({ content: "This channel added as a private announcement channel for **Tournament 1**!" })
 			);
 		})
 	);

--- a/test/commands/addhost.unit.ts
+++ b/test/commands/addhost.unit.ts
@@ -17,7 +17,7 @@ describe("command:addhost", function () {
 		msg.channel.createMessage = sinon.spy();
 		await command.executor(msg, ["name"], support);
 		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			sinon.match({ content: "<@nova> added as a host for Tournament name!" })
+			sinon.match({ content: "<@nova> added as a host for **Tournament 1**!" })
 		);
 	});
 });

--- a/test/commands/common.ts
+++ b/test/commands/common.ts
@@ -5,6 +5,7 @@ import sinon, { SinonSandbox } from "sinon";
 import sinonChai from "sinon-chai";
 import sinonTest from "sinon-test";
 import { CommandDefinition, CommandSupport } from "../../src/Command";
+import { DatabaseTournament, TournamentFormat, TournamentStatus } from "../../src/database/interface";
 import { DeckManager } from "../../src/deck";
 import { DiscordInterface } from "../../src/discord/interface";
 import { OrganiserRoleProvider } from "../../src/role/organiser";
@@ -43,6 +44,22 @@ export function itRejectsNonHosts(
 export const mockBotClient = new Client("mock");
 // For the purposes of most commands, most fields don't matter. This is the minimum to make the constructor run.
 export const msg = new Message({ id: "007", channel_id: "foo", author: { id: "0000" } }, mockBotClient);
+// for the purposes of testing, needs a valid name to be displayed by command responses
+export const tournament: DatabaseTournament = {
+	name: "Tournament 1",
+	id: "name",
+	description: "",
+	format: TournamentFormat.SWISS,
+	status: TournamentStatus.IPR,
+	hosts: [],
+	players: [],
+	limit: 256,
+	server: "",
+	publicChannels: [],
+	privateChannels: [],
+	byes: [],
+	findPlayer: sinon.stub()
+};
 
 export const support: CommandSupport = {
 	discord: new DiscordInterface(new DiscordWrapperMock()),

--- a/test/commands/create.unit.ts
+++ b/test/commands/create.unit.ts
@@ -39,7 +39,7 @@ describe("command:create", function () {
 			expect(msg.channel.createMessage).to.have.been.calledWithExactly(
 				sinon.match({
 					content:
-						"**Tournament 1** created! You can find it at https://example.com/battlecity. For future commands, refer to this tournament by the id `battlecity`."
+						"Tournament battlecity created! You can find it at https://example.com/battlecity. For future commands, refer to this tournament by the id `battlecity`."
 				})
 			);
 			expect(msg.channel.createMessage).to.have.been.calledWithExactly(

--- a/test/commands/create.unit.ts
+++ b/test/commands/create.unit.ts
@@ -39,7 +39,7 @@ describe("command:create", function () {
 			expect(msg.channel.createMessage).to.have.been.calledWithExactly(
 				sinon.match({
 					content:
-						"Tournament battlecity created! You can find it at https://example.com/battlecity. For future commands, refer to this tournament by the id `battlecity`."
+						"**Tournament 1** created! You can find it at https://example.com/battlecity. For future commands, refer to this tournament by the id `battlecity`."
 				})
 			);
 			expect(msg.channel.createMessage).to.have.been.calledWithExactly(

--- a/test/commands/csv.unit.ts
+++ b/test/commands/csv.unit.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import dotenv from "dotenv";
 import sinon, { SinonSandbox } from "sinon";
 import command from "../../src/commands/csv";
-import { itRejectsNonHosts, msg, support, test } from "./common";
+import { itRejectsNonHosts, msg, support, test, tournament } from "./common";
 
 dotenv.config();
 describe("command:csv", function () {
@@ -37,7 +37,7 @@ describe("command:csv", function () {
 	it(
 		"warns on an empty tournament",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.database, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves(tournament);
 			const listStub = this.stub(support.database, "getConfirmed").resolves([]);
 			msg.channel.createMessage = this.spy();
 			await command.executor(msg, args, support);
@@ -45,7 +45,7 @@ describe("command:csv", function () {
 			expect(listStub).to.have.been.calledOnce;
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
 				sinon.match({
-					content: "Tournament battlecity has no players!"
+					content: "**Tournament 1** has no players!"
 				})
 			);
 		})
@@ -91,7 +91,7 @@ describe("command:csv", function () {
 	it(
 		"does not catch reply exceptions",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.database, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves(tournament);
 			const listStub = this.stub(support.database, "getConfirmed").resolves([]);
 			msg.channel.createMessage = this.stub().rejects();
 			try {
@@ -102,7 +102,7 @@ describe("command:csv", function () {
 				expect(listStub).to.have.been.calledOnce;
 				expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
 					sinon.match({
-						content: "Tournament battlecity has no players!"
+						content: "**Tournament 1** has no players!"
 					})
 				);
 			}

--- a/test/commands/finish.unit.ts
+++ b/test/commands/finish.unit.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import sinon, { SinonSandbox } from "sinon";
 import command from "../../src/commands/finish";
-import { itRejectsNonHosts, msg, support, test } from "./common";
+import { itRejectsNonHosts, msg, support, test, tournament } from "./common";
 
 describe("command:finish", function () {
 	const args = ["battlecity"];
@@ -9,14 +9,14 @@ describe("command:finish", function () {
 	it(
 		"finishes the tournament",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.database, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves(tournament);
 			const finishStub = this.stub(support.tournamentManager, "finishTournament").resolves();
 			msg.channel.createMessage = this.spy();
 			await command.executor(msg, args, support);
 			expect(authStub).to.have.been.called;
 			expect(finishStub).to.have.been.calledOnceWithExactly("battlecity", false);
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-				sinon.match({ content: "Tournament battlecity successfully finished." })
+				sinon.match({ content: "**Tournament 1** successfully finished." })
 			);
 		})
 	);
@@ -24,7 +24,7 @@ describe("command:finish", function () {
 	it(
 		"suggests early on finishTournament exceptions",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.database, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves(tournament);
 			const finishStub = this.stub(support.tournamentManager, "finishTournament").rejects();
 			msg.channel.createMessage = this.spy();
 			// no try catch because executor does not throw, it handles error
@@ -34,7 +34,7 @@ describe("command:finish", function () {
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
 				sinon.match({
 					content:
-						"Tournament battlecity is not finished. If you intend to end it early, use `mc!finish battlecity|early`."
+						"**Tournament 1** is not finished. If you intend to end it early, use `mc!finish battlecity|early`."
 				})
 			);
 		})
@@ -42,14 +42,14 @@ describe("command:finish", function () {
 	it(
 		"finishes the tournament early",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.database, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves(tournament);
 			const finishStub = this.stub(support.tournamentManager, "finishTournament").resolves();
 			msg.channel.createMessage = this.spy();
 			await command.executor(msg, [...args, "early"], support);
 			expect(authStub).to.have.been.called;
 			expect(finishStub).to.have.been.calledOnceWithExactly("battlecity", true);
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-				sinon.match({ content: "Tournament battlecity successfully finished." })
+				sinon.match({ content: "**Tournament 1** successfully finished." })
 			);
 		})
 	);
@@ -72,7 +72,7 @@ describe("command:finish", function () {
 	it(
 		"does not catch reply exceptions",
 		test(async function (this: SinonSandbox) {
-			const authStub = this.stub(support.database, "authenticateHost").resolves();
+			const authStub = this.stub(support.database, "authenticateHost").resolves(tournament);
 			const finishStub = this.stub(support.tournamentManager, "finishTournament").resolves();
 			msg.channel.createMessage = this.stub().rejects();
 			try {

--- a/test/commands/open.unit.ts
+++ b/test/commands/open.unit.ts
@@ -9,7 +9,7 @@ describe("command:open", function () {
 		msg.channel.createMessage = sinon.spy();
 		await command.executor(msg, ["name"], support);
 		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			sinon.match({ content: "Tournament name opened for registration!" })
+			sinon.match({ content: "**Tournament 1** opened for registration!" })
 		);
 	});
 });

--- a/test/commands/removebye.unit.ts
+++ b/test/commands/removebye.unit.ts
@@ -20,7 +20,7 @@ describe("command:removebye", function () {
 			this.stub(support.database, "removeBye").resolves([]);
 			await command.executor(msg, ["name"], support);
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-				sinon.match({ content: "Bye removed for Player <@nova> (nova) in Tournament name!\nAll byes: " })
+				sinon.match({ content: "Bye removed for Player <@nova> (nova) in **Tournament 1**!\nAll byes: " })
 			);
 		})
 	);

--- a/test/commands/removechannel.unit.ts
+++ b/test/commands/removechannel.unit.ts
@@ -9,21 +9,21 @@ describe("command:removechannel", function () {
 		msg.channel.createMessage = sinon.spy();
 		await command.executor(msg, ["name"], support);
 		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			sinon.match({ content: "This channel removed as a public announcement channel for Tournament name!" })
+			sinon.match({ content: "This channel removed as a public announcement channel for **Tournament 1**!" })
 		);
 	});
 	it("removes public channels", async () => {
 		msg.channel.createMessage = sinon.spy();
 		await command.executor(msg, ["name", "public"], support);
 		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			sinon.match({ content: "This channel removed as a public announcement channel for Tournament name!" })
+			sinon.match({ content: "This channel removed as a public announcement channel for **Tournament 1**!" })
 		);
 	});
 	it("removes private channels", async () => {
 		msg.channel.createMessage = sinon.spy();
 		await command.executor(msg, ["name", "private"], support);
 		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			sinon.match({ content: "This channel removed as a private announcement channel for Tournament name!" })
+			sinon.match({ content: "This channel removed as a private announcement channel for **Tournament 1**!" })
 		);
 	});
 });

--- a/test/commands/removehost.unit.ts
+++ b/test/commands/removehost.unit.ts
@@ -11,7 +11,7 @@ describe("command:removehost", function () {
 		msg.channel.createMessage = sinon.spy();
 		await command.executor(msg, ["name", "<@!snowflake>"], support);
 		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			sinon.match({ content: "<@snowflake> removed as a host for Tournament name!" })
+			sinon.match({ content: "<@snowflake> removed as a host for **Tournament 1**!" })
 		);
 	});
 	it("supports user ids", async () => {
@@ -19,7 +19,7 @@ describe("command:removehost", function () {
 		msg.channel.createMessage = sinon.spy();
 		await command.executor(msg, ["name", "raw-snowflake"], support);
 		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			sinon.match({ content: "<@raw-snowflake> removed as a host for Tournament name!" })
+			sinon.match({ content: "<@raw-snowflake> removed as a host for **Tournament 1**!" })
 		);
 	});
 });

--- a/test/commands/sync.unit.ts
+++ b/test/commands/sync.unit.ts
@@ -9,7 +9,7 @@ describe("command:sync", function () {
 		msg.channel.createMessage = sinon.spy();
 		await command.executor(msg, ["name"], support);
 		expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
-			sinon.match({ content: "Tournament name database successfully synchronised with remote website." })
+			sinon.match({ content: "**Tournament 1** database successfully synchronised with remote website." })
 		);
 	});
 });

--- a/test/commands/tb.unit.ts
+++ b/test/commands/tb.unit.ts
@@ -30,7 +30,7 @@ describe("command:tb", function () {
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
 				sinon.match({
 					content:
-						"Tie-breaker settings updated for Tournament name.\n1. Match Wins\n2. Game/Set Wins\n3. Points Scored"
+						"Tie-breaker settings updated for **Tournament 1**.\n1. Match Wins\n2. Game/Set Wins\n3. Points Scored"
 				})
 			);
 		})
@@ -45,7 +45,7 @@ describe("command:tb", function () {
 			expect(msg.channel.createMessage).to.have.been.calledOnceWithExactly(
 				sinon.match({
 					content:
-						"Could not update tie-breakers for Tournament name. You must provide three valid options in priority order. The valid options and their corresponding meaning are:\n" +
+						"Could not update tie-breakers for **Tournament 1**. You must provide three valid options in priority order. The valid options and their corresponding meaning are:\n" +
 						"`match wins` (Match Wins)\n`game wins` (Game/Set Wins)\n`game win percentage` (Game/Set Win %)\n`points scored` (Points Scored)\n`points difference` (Points Difference)\n`match wins vs tied` (Wins vs Tied Participants)\n`median buchholz` (Median-Buchholz system)"
 				})
 			);


### PR DESCRIPTION
## Description

Choosing the more visually appealing option for an inconsistently-handled UX choice.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
