### PR TITLE
Use content.messageReference instead of deprecrated content.messageReferenceID

### DIFF
--- a/src/util/discord.ts
+++ b/src/util/discord.ts
@@ -6,7 +6,9 @@ export async function reply(
 	...args: Parameters<Textable["createMessage"]>
 ): ReturnType<Textable["createMessage"]> {
 	const mixin = {
-		messageReferenceID: msg.id,
+		messageReference: {
+			messageID: msg.id
+		},
 		allowedMentions: {
 			repliedUser: true
 		}


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

[DEPRECATED] content.messageReferenceID is deprecated. Use content.messageReference instead

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
