### PR TITLE
Fix all attachments broken by switching to Discord.js

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## HEAD ([Chalislime Monthly August 2021](https://challonge.com/csmaugust2021))
+
+### New Features
+- Switch to Discord.js from Eris so we can make use of recent Discord features (#325)
+
+### Bug Fixes
+- Fix all file attachments breaking due to the switch to Discord.js, breaking two commands and part of registration (#327)
+
 ## 2021-07-31 ([Chalislime Monthly July 2021](https://challonge.com/csmjuly2021))
 ### New Features
 - `mc!dump`, `mc!players` and `mc!pie` have been merged into one command, `mc!csv`. (#303)

--- a/src/commands/banlist.ts
+++ b/src/commands/banlist.ts
@@ -139,7 +139,10 @@ const command: CommandDefinition = {
 			const memo = tournament.allowVector
 				? `Here is the custom allowed card pool for **${tournament.name}** in vector form.\nSHA256: \`${hash}\``
 				: `This is the _default_ allowed card pool in vector form.\nSHA256: \`${hash}\``;
-			await msg.reply({ content: memo, files: [new MessageAttachment(file, `${id}.allowVector.json`)] });
+			await msg.reply({
+				content: memo,
+				files: [new MessageAttachment(Buffer.from(file), `${id}.allowVector.json`)]
+			});
 		}
 	}
 };

--- a/src/commands/csv.ts
+++ b/src/commands/csv.ts
@@ -27,7 +27,7 @@ const command: CommandDefinition = {
 			await msg.reply(`**${tournament.name}** has no players!`);
 			return;
 		}
-		let file;
+		let file: Buffer;
 		if (pie) {
 			const themes = players
 				.map(player => {
@@ -35,7 +35,7 @@ const command: CommandDefinition = {
 					return deck.themes.length > 0 ? deck.themes.join("/") : "No themes";
 				})
 				.reduce((map, theme) => map.set(theme, (map.get(theme) || 0) + 1), new Map<string, number>());
-			file = await csv.writeToString([["Theme", "Count"], ...themes.entries()]);
+			file = await csv.writeToBuffer([["Theme", "Count"], ...themes.entries()]);
 		} else {
 			const rows = await Promise.all(
 				players.map(async player => {
@@ -49,7 +49,7 @@ const command: CommandDefinition = {
 					};
 				})
 			);
-			file = await csv.writeToString(rows, { headers: true });
+			file = await csv.writeToBuffer(rows, { headers: true });
 		}
 		logger.verbose(
 			JSON.stringify({

--- a/src/deck.ts
+++ b/src/deck.ts
@@ -205,7 +205,7 @@ export class DeckManager {
 
 		return {
 			embeds: [new MessageEmbed().setTitle(title).addFields(fields)],
-			files: [{ name, attachment: deck.ydk }]
+			files: [{ name, attachment: Buffer.from(deck.ydk) }]
 		};
 	}
 

--- a/test/commands/csv.unit.ts
+++ b/test/commands/csv.unit.ts
@@ -28,7 +28,9 @@ describe("command:csv", function () {
 				files: [
 					{
 						name: "battlecity.csv",
-						attachment: `Player,Theme,Deck\n1312,No themes,"Main: , Extra: , Side: "\n1314,No themes,"Main: , Extra: , Side: "\n1234,No themes,"Main: , Extra: , Side: "`
+						attachment: Buffer.from(
+							`Player,Theme,Deck\n1312,No themes,"Main: , Extra: , Side: "\n1314,No themes,"Main: , Extra: , Side: "\n1234,No themes,"Main: , Extra: , Side: "`
+						)
 					}
 				]
 			});
@@ -64,7 +66,7 @@ describe("command:csv", function () {
 				files: [
 					{
 						name: "battlecity.csv",
-						attachment: `Theme,Count\nNo themes,3`
+						attachment: Buffer.from("Theme,Count\nNo themes,3")
 					}
 				]
 			});

--- a/test/commands/deck.unit.ts
+++ b/test/commands/deck.unit.ts
@@ -46,7 +46,7 @@ describe("command:deck", function () {
 			const reply = replySpy.args[0][0] as ReplyMessageOptions;
 			const file = reply.files?.[0] as FileOptions;
 			expect(file.name).to.equal("K.0000.ydk");
-			expect(file.attachment).to.equal(sampleDeck.ydk);
+			expect(file.attachment.toString()).to.equal(sampleDeck.ydk);
 		})
 	);
 });

--- a/test/deck.ts
+++ b/test/deck.ts
@@ -69,7 +69,7 @@ describe("Test embeds", function () {
 		const messageContent = decks.prettyPrint(deck, "test.ydk");
 		const file = messageContent?.files?.[0] as FileOptions;
 		expect(file.name).to.equal("test.ydk");
-		expect(file.attachment).to.equal(
+		expect(file.attachment.toString()).to.equal(
 			"#created by YDeck\n#main\n89631139\n89631139\n89631139\n95788410\n95788410\n95788410\n39674352\n39674352\n39674352\n32626733\n32626733\n32626733\n56649609\n56649609\n56649609\n38999506\n38999506\n38999506\n39111158\n39111158\n39111158\n92176681\n92176681\n92176681\n65957473\n65957473\n65957473\n76232340\n76232340\n76232340\n38955728\n38955728\n38955728\n13140300\n13140300\n13140300\n89189982\n89189982\n89189982\n31447217\n#extra\n62873545\n62873545\n62873545\n!side\n31447217\n31447217\n"
 		);
 		const embed = messageContent?.embeds?.[0];
@@ -96,7 +96,7 @@ describe("Test embeds", function () {
 		]);
 		const file = messageContent?.files?.[0] as FileOptions;
 		expect(file.name).to.equal("blank.ydk");
-		expect(file.attachment).to.equal("#created by YDeck\n#main\n#extra\n!side\n");
+		expect(file.attachment.toString()).to.equal("#created by YDeck\n#main\n#extra\n!side\n");
 		const embed = messageContent?.embeds?.[0];
 		expect(embed?.title).to.equal("Themes: none");
 		const errorField = embed?.fields?.[1];


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

String type for BufferResolvable is treated as file name, not contents: https://discord.js.org/#/docs/main/stable/typedef/BufferResolvable

This resulted in the program attempting to find a file in its filesystem with a long name equal to the contents of the deck, which always failed due to the long names. The errors often failed to be sent to the Discord webhook, since the payload contained the entire deck string, exceeding the size limit.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
