### PR TITLE
Ignore all-pings for the purpose of the help message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## HEAD ([Chalislime Monthly August 2021](https://challonge.com/csmaugust2021))
+## HEAD
 
 ### New Features
 - Switch to Discord.js from Eris so we can make use of recent Discord features (#325)
 
 ### Bug Fixes
 - Fix all file attachments breaking due to the switch to Discord.js, breaking two commands and part of registration (#327)
+- Do not respond to `@everyone` and `@here`, another effect of the change to Discord.js (#329)
 
 ## 2021-07-31 ([Chalislime Monthly July 2021](https://challonge.com/csmjuly2021))
 ### New Features

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 
 ### Bug Fixes
 - Fix all file attachments breaking due to the switch to Discord.js, breaking two commands and part of registration (#327)
-- Do not respond to `@everyone` and `@here`, another effect of the change to Discord.js (#329)
+- Do not respond to `@everyone` and `@here`, another effect of the change to Discord.js (#330)
 
 ## 2021-07-31 ([Chalislime Monthly July 2021](https://challonge.com/csmjuly2021))
 ### New Features

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -28,7 +28,7 @@ export function makeHandler(
 		if (msg.author.bot || msg.reference) {
 			return;
 		}
-		if (bot.user && msg.mentions.has(bot.user)) {
+		if (bot.user && msg.mentions.has(bot.user, { ignoreEveryone: true })) {
 			await msg.reply(helpMessage).catch(logger.error);
 			return;
 		}


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

Due to the change to Discord.js, its MessageMentions#has behaves slightly differently, by default returning true for `@everyone` and `@here`. This fixes the regression and unnecessary error logs from not being able to respond in announcement channel.

Documentation: https://discord.js.org/#/docs/main/stable/class/MessageMentions?scrollTo=has

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
