### PR TITLE
Reduce noise of high severity logs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 - Fix all file attachments breaking due to the switch to Discord.js, breaking two commands and part of registration (#327)
 - Do not respond to `@everyone` and `@here`, another effect of the change to Discord.js (#330)
+- Fix register messages being deleted on bot startup (#332)
 
 ## 2021-07-31 ([Chalislime Monthly July 2021](https://challonge.com/csmjuly2021))
 ### New Features

--- a/src/commands/forcedrop.ts
+++ b/src/commands/forcedrop.ts
@@ -57,14 +57,14 @@ const command: CommandDefinition = {
 				try {
 					await support.participantRole.ungrant(player, tournament);
 				} catch (error) {
-					logger.warn(error);
+					logger.info(error);
 					await msg
 						.reply(`Failed to remove **${tournament.name}** participant role from ${name}.`)
 						.catch(logger.error);
 				}
 			} else {
 				await msg.reply(
-					"Something went wrong. Please check private channels for problems and try again later."
+					"Something went wrong with Challonge. Please check private channels for problems and try again later."
 				);
 				return;
 			}
@@ -74,13 +74,15 @@ const command: CommandDefinition = {
 			await participant.remove();
 		} catch (error) {
 			logger.error(error);
-			await msg.reply("Something went wrong. Please check private channels for problems and try again later.");
+			await msg.reply(
+				"Something went wrong with Emcee's database. Please report this to developers as this may not be immediately recoverable."
+			);
 			return;
 		}
 		// Notify relevant parties as long as the participant existed
 		await support.discord
 			.sendDirectMessage(player, `You have been dropped from **${tournament.name}** by the hosts.`)
-			.catch(logger.error);
+			.catch(logger.info);
 		for (const channel of tournament.privateChannels) {
 			await support.discord
 				.sendMessage(channel, `${name} has been forcefully dropped from **${tournament.name}**.`)

--- a/src/commands/score.ts
+++ b/src/commands/score.ts
@@ -74,7 +74,7 @@ const command: CommandDefinition = {
 					);
 				} catch (err) {
 					log("DM fail", { opponent });
-					logger.warn(err);
+					logger.info(err);
 					for (const channel of player.tournament.privateChannels) {
 						await support.discord
 							.sendMessage(channel, `Failed to send confirmation of score submission to <@${opponent}>.`)
@@ -109,7 +109,7 @@ const command: CommandDefinition = {
 					);
 				} catch (err) {
 					log("DM fail", { opponent });
-					logger.warn(err);
+					logger.info(err);
 					for (const channel of player.tournament.privateChannels) {
 						await support.discord
 							.sendMessage(channel, `Failed to send report of score disagreement to <@${opponent}>.`)

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -50,7 +50,7 @@ const command: CommandDefinition = {
 						player,
 						`Sorry, **${tournament.name}** has started and you didn't submit a deck, so you have been dropped.`
 					)
-					.catch(logger.warn);
+					.catch(logger.info);
 			}
 			logger.verbose(log("notify ejected"));
 			await support.challonge.shufflePlayers(id); // must happen before byes assigned!
@@ -80,6 +80,7 @@ const command: CommandDefinition = {
 		}
 		logger.verbose(log("private"));
 		// drop dummy players once the tournament has started to give players with byes the win
+		// TODO: due to the behaviour change documented in #329, this now deletes the byes before the tournament even starts
 		await support.challonge.dropByes(id, tournament.byes.length);
 		logger.info(log("success"));
 	}

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -13,8 +13,8 @@ export function registerEvents(bot: Client, prefix: string, support: CommandSupp
 	bot.on("warn", logger.warn);
 	bot.on("error", logger.error);
 	bot.on("shardReady", shard => logger.notify(`Shard ${shard} ready`));
-	bot.on("shardReconnecting", shard => logger.notify(`Shard ${shard} reconnecting`));
-	bot.on("shardResume", (shard, replayed) => logger.notify(`Shard ${shard} resumed: ${replayed} events replayed`));
+	bot.on("shardReconnecting", shard => logger.info(`Shard ${shard} reconnecting`));
+	bot.on("shardResume", (shard, replayed) => logger.info(`Shard ${shard} resumed: ${replayed} events replayed`));
 	bot.on("shardDisconnect", (event, shard) =>
 		logger.notify(`Shard ${shard} disconnected (${event.code},${event.wasClean}): ${event.reason}`)
 	);

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -196,7 +196,7 @@ async function verifyDeckAndConfirmPending(
 		await participantRole.grant(msg.author.id, tournament);
 		log("verbose", msg, { event: "role", tournament: tournament.id });
 	} catch (error) {
-		logger.error(error);
+		logger.info(error);
 		roleGrantWarning = " I couldn't assign them a role. Am I missing permissions?";
 	}
 	for (const channel of tournament.privateChannels) {

--- a/src/round.ts
+++ b/src/round.ts
@@ -173,7 +173,7 @@ async function reportFailure(
 	opponentId: string
 ): Promise<void> {
 	for (const channel of tournament.privateChannels) {
-		logger.warn(JSON.stringify({ tournament: tournament.id, userId, opponentId, event: "direct message fail" }));
+		logger.info(JSON.stringify({ tournament: tournament.id, userId, opponentId, event: "direct message fail" }));
 		await discord
 			.sendMessage(
 				channel,

--- a/test/tournamentManager.ts
+++ b/test/tournamentManager.ts
@@ -1,7 +1,7 @@
 import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import dotenv from "dotenv";
 import { Client } from "discord.js";
+import dotenv from "dotenv";
 import * as fs from "fs/promises";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
@@ -142,7 +142,7 @@ describe("Misc functions", function () {
 			"stestPlayer1"
 		);
 		expect(discord.getResponse("stestPlayer1")).to.equal(
-			"You are registering for Tournament 1. Please submit a deck to complete your registration, by uploading a YDK file or sending a message with a YDKE URL."
+			"You are registering for **Tournament 1**. Please submit a deck to complete your registration, by uploading a YDK file or sending a message with a YDKE URL."
 		);
 	});
 	it("Register player - blocked DMs", async function () {
@@ -162,7 +162,7 @@ describe("Misc functions", function () {
 		);
 		expect(discord.getResponse("sblockedPlayer")).to.be.undefined;
 		expect(discord.getResponse("channel2")).to.equal(
-			"Player <@sblockedPlayer> (sblockedPlayer) is trying to sign up for Tournament Tournament 1 (tourn1), but I cannot send them DMs. Please ask them to allow DMs from this server."
+			"<@sblockedPlayer> (sblockedPlayer) is trying to sign up for **Tournament 1** (tourn1), but I cannot send them DMs. Please ask them to allow DMs from this server."
 		);
 	});
 	it("Register player - no tournament", async function () {


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

- Downgrade severity of logs related to direct message failures to INFO since they are all due to being blocked (50013)
- Downgrade severity of gateway reconnection messages to INFO
- Fix unconditional AssertTextChannelErrors in DJS wrapper methods
- Fix register messages being deleted on boot due to a faulty getMessage port

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
